### PR TITLE
added new methods for language translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,123 @@ Sample usage:
 tj.play('/usr/share/doc/Greenfoot/scenarios/lunarlander/sounds/Explosion.wav');
 ```
 
+# Translate
+
+## tj.translate(text, sourceLanguage, targetLanguage)
+
+Translates the given text from the source language to the target language.
+
+- `sourceLanguage` is the 2 character string that identifies the language from which to translate
+- `targetLanguage` is the 2 character string that identifies the language to which to translate
+
+> Note: Not all languages can be translated to other languages! Use the method `tj.isTranslatable()` to determine if a translation model exists between a soruce and target langauge.
+
+Below are examples of common languages and the 2 character strings used to represent them.
+
+| Language | Code |
+|---|---|
+| Arabic | ar |
+| Chinese | zh |
+| German | de |
+| English | en |
+| French | fr |
+| Italian | it |
+| Japanese | ja |
+| Korean | ko |
+| Spanish | es |
+| Portuguese | pt |
+
+Sample usage:
+
+```
+tj.translate("Hello, my name is TJBot!", 'en', 'es').then(function(translation) {
+    ...
+});
+```
+
+Sample response:
+
+```
+translation = {
+	"translations":[
+		{
+			"translation":"Hola, mi nombre es TJBot!"
+		}
+	],
+	"word_count":5,
+	"character_count":24
+}
+```
+
+## tj.identifyLanguage(text)
+
+Identifies the language in which the text was written.
+
+- `text` is the text whose language should be identified
+
+Sample usage:
+
+```
+tj.identifyLanguage("Hello, my name is TJBot!").then(function(languages) {
+    ...
+});
+
+```
+
+Sample response:
+
+```
+languages = {
+	"languages":[
+		{
+			"language":"en",
+			"confidence":0.865653
+		},
+		{
+			"language":"af",
+			"confidence":0.039473
+		},
+		{
+			"language":"nl",
+			"confidence":0.0276556
+		},
+		{
+			"language":"nn",
+			"confidence":0.0216675
+		},
+		...
+	]
+}
+```
+
+## tj.isTranslatable(sourceLanguage, targetLanguage)
+
+Returns a Promise that resolves to `true` if there exists a translation model between the source language and the target language.
+
+- `sourceLanguage` is the 2 character string that identifies the source language
+- `targetLanguage` is the 2 character string that identifies the target language
+
+> Note: This method is asynchronous due to the need to load the list of translation models available. If you are confident that the list of translation models has been loaded (e.g. you call `tj.isTranslatable()` a few seconds after your script has been running), you may wish to use the internal method `tj._isTranslatable()` instead.
+
+Sample usage:
+
+```
+tj.isTranslatable('en', 'es').then(function(result) {
+    if (result) {
+        console.log("TJBot can translate between English and Spanish!");
+    } else {
+        console.log("TJBot cannot translate between English and Spanish.");
+    }
+});
+```
+
+Sample response:
+
+```
+TJBot can translate between English and Spanish!
+```
+
+
 # Wave
 
 ## tj.armBack()

--- a/README.md
+++ b/README.md
@@ -588,7 +588,6 @@ Sample response:
 TJBot can translate between English and Spanish!
 ```
 
-
 # Wave
 
 ## tj.armBack()

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -353,8 +353,13 @@ TJBot.prototype._createServiceAPI = function(service, credentials) {
             this._languageTranslator = new LanguageTranslatorV2({
                 username: credentials['username'],
                 password: credentials['password'],
-                version: 'v2'
-                // url: credentials['url']
+                version: 'v2',
+                url: 'https://gateway.watsonplatform.net/language-translator/api/'
+            });
+            
+            // load the list of language models
+            this._loadLanguageTranslations().then(function(translations) {
+                self._translations = translations;
             });
             break;
 
@@ -1169,6 +1174,145 @@ TJBot.prototype.play = function(soundFile) {
         
         player.play(soundFile);
     });
+}
+
+/** ------------------------------------------------------------------------ */
+/** TRANSLATE                                                                */
+/** ------------------------------------------------------------------------ */
+
+/**
+ * Translates the given tesxt from the source language to the target language.
+ * 
+ * @param {String} text The text to translate.
+ * @param {String} sourceLanguage The source language (e.g. "en" for English)
+ * @param {String} targetLanguage The target language (e.g. "es" for Spanish)
+ */
+TJBot.prototype.translate = function(text, sourceLanguage, targetLanguage) {
+    this._assertCapability('translate');
+    
+    // capture 'this' context
+    var self = this;
+    
+    return new Promise(function(resolve, reject) {
+        self._languageTranslator.translate({
+            text: text,
+            source: sourceLanguage,
+            target: targetLanguage
+        }, function(err, translation) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(translation);
+            }
+        });
+    });
+}
+
+/**
+ * Identifies the language of the given text.
+ * 
+ * @param {String} text The text to identify.
+ * 
+ * Returns a list of identified languages in the text.
+ */
+TJBot.prototype.identifyLanguage = function(text) {
+    this._assertCapability('translate');
+
+    // capture 'this' context
+    var self = this;
+    
+    return new Promise(function(resolve, reject) {
+        self._languageTranslator.identify({
+            text: text
+        }, function(err, identifiedLanguages) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(identifiedLanguages);
+            }
+        });
+    });
+}
+
+/**
+ * Determines if TJBot can translate from the source language to the target language.
+ * 
+ * @param {String} sourceLanguage The source language (e.g. "en" for English)
+ * @param {String} targetLanguage The target language (e.g. "es" for Spanish)
+ * 
+ * Returns a Promise that resolves to whether the sourceLanguage can be translated
+ * to the targetLanguage.
+ */
+TJBot.prototype.isTranslatable = function(sourceLanguage, targetLanguage) {
+    this._assertCapability('translate');
+    
+    // capture 'this' context
+    var self = this;
+    
+    // load the list of language models available for translation
+    if (this._translations == undefined) {
+        return this._loadLanguageTranslations().then(function(translations) {
+            self._translations = translations;
+            return self._isTranslatable(sourceLanguage, targetLanguage);
+        });
+    } else {
+        return new Promise(function(resolve, reject) {
+            resolve(self._isTranslatable(sourceLanguage, targetLanguage));
+        });
+    }
+}
+
+/**
+ * Loads the list of language models that can be used for translation.
+ */
+TJBot.prototype._loadLanguageTranslations = function() {
+    // capture 'this' context
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        if (self._translations == undefined) {
+            self._languageTranslator.getModels({}, function(err, models) {
+                var translations = {};
+                if (err) {
+                    console.error("error: unable to retrieve list of language models for translation");
+                    reject(err);
+                } else {
+                    if (models.hasOwnProperty('models')) {
+                        models.models.forEach((model) => {
+                            if (translations[model.source] == undefined) {
+                                translations[model.source] = [];
+                            }
+                            if (!translations[model.source].includes(model.target)) {
+                                translations[model.source].push(model.target);
+                            }
+                        });
+                    } else {
+                        console.error("error: unexpected result received for list of language models for translation");
+                        reject(err);
+                    }
+                }
+                resolve(translations);
+            });
+        } else {
+            resolve(translations);
+        }
+    });
+}
+
+/**
+ * Determines if TJBot can translate from the source language to the target language.
+ * Assumes that the language model list has been loaded.
+ * 
+ * @param {String} sourceLanguage The source language (e.g. "en" for English)
+ * @param {String} targetLanguage The target language (e.g. "es" for Spanish)
+ * 
+ * Returns true if the sourceLanguage can be translated to the targetLanguage.
+ */
+TJBot.prototype._isTranslatable = function(sourceLanguage, targetLanguage) {
+    if (this._translations[sourceLanguage] != undefined) {
+        return this._translations[sourceLanguage].includes(targetLanguage);
+    }
+    
+    return false;
 }
 
 /** ------------------------------------------------------------------------ */


### PR DESCRIPTION
![](http://financial-translator.com/wp-content/uploads/2015/08/18548614.jpg)

**Scope of Changes**

- added new methods for the `language_translation` service: `tj.translate()`, `tj.identifyLanguage()`, `tj.isTranslatable()`
- added documentation for the new methods
- fixed a bug in the instantiation of the Watson service (it needs `url` specified)