### PR TITLE
Correct error checking on misunderstood conversations

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -1062,9 +1062,10 @@ TJBot.prototype._normalizeColor = function(color) {
 TJBot.prototype.speak = function(message) {
     this._assertCapability('speak');
 
-    // make sure we're trying to say something
-    if (message == undefined) {
-        throw new Error("TJBot tried to speak an empty message.");
+    // make sure we're trying to say something that we have been trained to understand
+    if (message == undefined || message == '') {
+        message = 'Sorry, I did not understand';
+        //throw new Error("TJBot tried to speak an empty message.");
     }
 
     // default voice


### PR DESCRIPTION
The code would crash if txt after the robot name trigger was not recognised by the conversation service. I added error checking and a useful response.