### PR TITLE
Fixed a bug in listen()

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -619,6 +619,10 @@ TJBot.prototype.listen = function(callback) {
     // capture 'this' context
     var self = this;
 
+    // (re)initialize the microphone because if stopListening() was called, we don't seem to
+    // be able to re-use the microphone twice
+    this._setupMicrophone();
+    
     // create the microphone -> STT recognizer stream
     // see this page for additional documentation on the STT configuration parameters:
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets

--- a/test/config.default.js
+++ b/test/config.default.js
@@ -1,0 +1,9 @@
+// Create the credentials object for export
+exports.credentials = {};
+
+// Watson Speech to Text
+// https://www.ibm.com/watson/developercloud/speech-to-text.html
+exports.credentials.speech_to_text = {
+    password: '',
+    username: ''
+};

--- a/test/test.listen.js
+++ b/test/test.listen.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TJBot = require('../lib/tjbot');
+const config = require('./config');
+
+var credentials = config.credentials;
+var hardware = ['microphone'];
+
+// turn on debug logging to the console
+var tjConfig = {
+    log: {
+        level: 'silly'
+    }
+};
+
+// instantiate our TJBot!
+var tj = new TJBot(hardware, tjConfig, credentials);
+
+// listen for speech
+console.log("listening for 5 seconds");
+
+tj.listen(function(msg) {
+    console.log("received a message");
+});
+
+setTimeout(function() {
+    console.log("timer fired, stoping listening");
+    tj.stopListening();
+}, 5000);
+
+setTimeout(function() {
+    console.log("goodbye!");
+}, 20000);
+
+setTimeout(function() {
+    console.log("timer fired, starting listening again");
+    tj.listen(function(msg) {
+        console.log("received a message");
+    });
+}, 10000);


### PR DESCRIPTION
**Scope of Changes**
- Fixed a bug in which calling `listen()`, then `stopListen()`, then `listen()` again would cause the second `listen()` to throw an error about writing data to a stream that had been closed
- Added a test for `listen()`, which isn't a *true* test, but helped me debug the issue. @victordibia We can talk about whether tests like this should be checked in or not.