### PR TITLE
Improved camera operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,22 @@ objects =
 ]
 ```
 
+### tj.recognizeObjectsInPhoto(filePath)
+
+Returns a list of objects seen and their confidences in the given photo.
+
+- `filePath` is the path to the photo to use.
+
+Sample usage:
+
+```
+tj.recognizeObjectsInPhoto(filePath).then(function(objects)) {
+    ...
+});
+```
+
+The response is the same as `tj.see()`.
+
 ### tj.read()
 
 Returns a list of text strings read by TJBot.
@@ -395,6 +411,22 @@ Sample response:
 ```
 TBD
 ```
+
+### tj.recognizeTextInPhoto(filePath)
+
+Returns a list of text strings read by TJBot in the given photo.
+
+- `filePath` is the path to the photo to use.
+
+Sample usage:
+
+```
+tj.recognizeTextInPhoto(filePath).then(function(texts)) {
+    ...
+});
+```
+
+The response is the same as `tj.read()`.
 
 ### tj.takePhoto(targetPath)
 

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -623,7 +623,7 @@ TJBot.prototype.listen = function(callback) {
     // (re)initialize the microphone because if stopListening() was called, we don't seem to
     // be able to re-use the microphone twice
     this._setupMicrophone();
-    
+
     // create the microphone -> STT recognizer stream
     // see this page for additional documentation on the STT configuration parameters:
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
@@ -774,8 +774,6 @@ TJBot.prototype.recognizeObjectsInPhoto = function(filePath) {
     });
 }
 
-
-
 /**
  * Take a picture and read the identified text.
  *
@@ -822,7 +820,6 @@ TJBot.prototype.recognizeTextInPhoto = function(filePath) {
     });
 }
 
-
 /**
  * Capture an image and save it in the given path. If no path is provided, it saves this file to a temp location
  *
@@ -864,32 +861,6 @@ TJBot.prototype.takePhoto = function(filePath) {
             reject(error);
         });
     })
-}
-
-/**
- * Capture an image and save it in the given path.
- *
- * @param {String} filePath The path at which to save the image.
- *
- * Returns the photo data in a Buffer.
- */
-TJBot.prototype._captureImage = function(filePath) {
-    this._assertCapability('see');
-
-    // capture 'this' context
-    var self = this;
-
-    winston.debug("capturing image at path: " + filePath + ".jpg");
-
-    var path = filePath.substring(0, filePath.lastIndexOf("/"));
-    var name = filePath.substring(filePath.lastIndexOf("/") + 1);
-
-    this._camera.setOptions({
-        outputDir: path,
-        fileName: name
-    });
-
-    return this._camera.takePhoto();
 }
 
 /** ------------------------------------------------------------------------ */

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -127,7 +127,7 @@ function TJBot(hardware, configuration, credentials) {
 /**
  * TJBot module version
  */
-TJBot.prototype.version = 'v1.2.0';
+TJBot.prototype.version = 'v1.2.1';
 
 /**
  * List of TJBot hardware and services.
@@ -199,8 +199,23 @@ TJBot.prototype._setupCamera = function() {
         encoding: 'jpg',
         outputDir: './',
         verticalFlip: this.configuration.see.camera.verticalFlip,
-        horizontalFlip: this.configuration.see.camera.horizontalFlip
+        horizontalFlip: this.configuration.see.camera.horizontalFlip,
+        time: 1
     });
+    
+    // versions of node-raspistill < 0.0.11 don't have the `time` option, so
+    // force it in if we don't find it
+    if (!this._camera.options.hasOwnProperty('time')) {
+        winston.silly("node-raspistill camera option for `time` not found, swizzling it in");
+        var self = this._camera;
+        self.processOptionsOriginal = self.processOptions;
+        self.processOptions = function(newOptions) {
+            var options = self.processOptionsOriginal(newOptions);
+            options.push('-t');
+            options.push('1');
+            return options;
+        }
+    }
 }
 
 /**
@@ -847,9 +862,14 @@ TJBot.prototype.takePhoto = function(filePath) {
     name = filePath.substring(filePath.lastIndexOf("/") + 1);
     name = name.replace(".jpg", ""); // the node raspistill lib already adds encoding .jpg to file.
 
+    // set the configuration options, which may have changed since the camera was initialized
     this._camera.setOptions({
         outputDir: path,
-        fileName: name
+        fileName: name,
+        width: this.configuration.see.camera.width,
+        height: this.configuration.see.camera.height,
+        verticalFlip: this.configuration.see.camera.verticalFlip,
+        horizontalFlip: this.configuration.see.camera.horizontalFlip
     });
 
     return new Promise(function(resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tjbot",
   "description": "Node.js library for writing TJBot recipes",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Justin Weisz <jweisz@us.ibm.com>",
   "bugs": {
     "url": "https://github.com/ibmtjbot/tjbotlib/issues"
@@ -14,7 +14,7 @@
     "colornames": "^1.1.1",
     "fifo": "^2.3.0",
     "mic": "^2.1.1",
-    "node-raspistill": "0.0.9",
+    "node-raspistill": "^0.0.11",
     "object.pick": "^1.2.0",
     "semaphore": "^1.0.5",
     "sleep": "^5.0.0",

--- a/test/test.play.js
+++ b/test/test.play.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TJBot = require('../lib/tjbot');
+const config = require('./config');
+
+var credentials = config.credentials;
+var hardware = ['speaker'];
+
+// turn on debug logging to the console
+var tjConfig = {
+    log: {
+        level: 'silly'
+    }
+};
+
+// instantiate our TJBot!
+var tj = new TJBot(hardware, tjConfig, credentials);
+
+// play a sound file
+var sound = "/usr/share/sounds/alsa/Front_Center.wav";
+
+console.log("playing sound");
+tj.play(sound).then(function() {
+    console.log("sound should have played");
+});


### PR DESCRIPTION
**Scope of Changes**

- Added documentation of `tj.recognizeObjectsInPhoto()`, `tj.recognizeTextInPhoto()`
- Removed ununsed method `tj._captureImage()`
- Added `time` property to node-raspistill camera options (and swizzling it in just in case, if for some reason, the version of node-raspistill doesn't support the `time` property) in order to speed up image capture from the pi camera
- Requiring node-raspistill greater or equal to 0.0.11 to support the `time` property
- Setting some additional camera options every time we take a photo, just in case the user changed those options in between taking photos (e.g. width, height, vflip, hflip)
- Bumped version to 1.2.1