### PR TITLE
Reduce color set to those that are easily recognized via STT

### DIFF
--- a/lib/tjbot-colors.js
+++ b/lib/tjbot-colors.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = [
+    { name: "aqua", value: "#00FFFF" },
+    { name: "banana", value: "#E3CF57" },
+    { name: "beige", value: "#F5F5DC" },
+    { name: "blue", value: "#0000FF" },
+    { name: "brick", value: "#9C661F" },
+    { name: "brown", value: "#A52A2A" },
+    { name: "carrot", value: "#ED9121" },
+    { name: "chartreuse", value: "#7FFF00" },
+    { name: "chocolate", value: "#D2691E" },
+    { name: "cobalt", value: "#3D59AB" },
+    { name: "coral", value: "#FF7F50" },
+    { name: "crimson", value: "#DC143C" },
+    { name: "cyan", value: "#00FFFF" },
+    { name: "fuchsia", value: "#FF00FF" },
+    { name: "gold", value: "#FFD700" },
+    { name: "gray", value: "#808080" },
+    { name: "green", value: "#008000" },
+    { name: "indigo", value: "#4B0082" },
+    { name: "ivory", value: "#FFFFF0" },
+    { name: "lavender", value: "#E6E6FA" },
+    { name: "lime", value: "#00FF00" },
+    { name: "magenta", value: "#FF00FF" },
+    { name: "maroon", value: "#800000" },
+    { name: "melon", value: "#E3A869" },
+    { name: "mint", value: "#BDFCC9" },
+    { name: "navy", value: "#000080" },
+    { name: "olive", value: "#808000" },
+    { name: "orange", value: "#FF8000" },
+    { name: "orchid", value: "#DA70D6" },
+    { name: "peacock", value: "#33A1C9" },
+    { name: "pink", value: "#FFC0CB" },
+    { name: "plum", value: "#DDA0DD" },
+    { name: "purple", value: "#800080" },
+    { name: "raspberry", value: "#872657" },
+    { name: "red", value: "#FF0000" },
+    { name: "salmon", value: "#FA8072" },
+    { name: "sepia", value: "#5E2612" },
+    { name: "sienna", value: "#A0522D" },
+    { name: "silver", value: "#C0C0C0" },
+    { name: "snow", value: "#FFFAFA" },
+    { name: "tan", value: "#D2B48C" },
+    { name: "teal", value: "#008080" },
+    { name: "thistle", value: "#D8BFD8" },
+    { name: "tomato", value: "#FF6347" },
+    { name: "turquoise", value: "#40E0D0" },
+    { name: "violet", value: "#EE82EE" },
+    { name: "white", value: "#FFFFFF" },
+    { name: "yellow", value: "#FFFF00" }
+];

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -24,7 +24,6 @@ const await = require('asyncawait/await');
 const Promise = require('bluebird');
 const fs = require('fs');
 const sleep = require('sleep');
-const colorToHex = require('colornames');
 const cm = require('color-model');
 const spawn = require('child_process').spawn;
 const winston = require('winston');
@@ -33,6 +32,9 @@ const winston = require('winston');
 const APlay = require('aplay');
 const Mic = require('mic');
 const Raspistill = require('node-raspistill').Raspistill;
+
+// local modules
+const TJBotColors = require('./tjbot-colors');
 
 /**
  * TJBot
@@ -623,7 +625,7 @@ TJBot.prototype.listen = function(callback) {
     // (re)initialize the microphone because if stopListening() was called, we don't seem to
     // be able to re-use the microphone twice
     this._setupMicrophone();
-    
+
     // create the microphone -> STT recognizer stream
     // see this page for additional documentation on the STT configuration parameters:
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
@@ -1048,7 +1050,7 @@ TJBot.prototype.stopPulsing = function() {
 TJBot.prototype.shineColors = function() {
     this._assertCapability('shine');
 
-    return colorToHex.all().map(function(elt, i, array) {
+    return TJBotColors.map(function(elt, i, array) {
         return elt['name'];
     });
 }

--- a/test/test.color.js
+++ b/test/test.color.js
@@ -20,7 +20,7 @@ const assert = require('assert');
 describe('TJBot', function() {
     describe('#shineColors', function() {
         it('should return the list of shine colors', function() {
-            var tj = new TJBot([], {}, {});
+            var tj = new TJBot(['led'], {}, {});
             var colors = tj.shineColors();
             assert.ok(colors.length > 0);
         });

--- a/test/test.color.js
+++ b/test/test.color.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TJBot = require('../lib/tjbot');
+const assert = require('assert');
+
+describe('TJBot', function() {
+    describe('#shineColors', function() {
+        it('should return the list of shine colors', function() {
+            var tj = new TJBot([], {}, {});
+            var colors = tj.shineColors();
+            assert.ok(colors.length > 0);
+        });
+    });
+    describe('#randomColor', function() {
+        it('should return a random color', function() {
+            var tj = new TJBot([], {}, {});
+            var color = tj.randomColor();
+            assert.ok(color);
+        })
+    })
+});

--- a/test/test.color.js
+++ b/test/test.color.js
@@ -27,7 +27,7 @@ describe('TJBot', function() {
     });
     describe('#randomColor', function() {
         it('should return a random color', function() {
-            var tj = new TJBot([], {}, {});
+            var tj = new TJBot(['led'], {}, {});
             var color = tj.randomColor();
             assert.ok(color);
         })


### PR DESCRIPTION
**Scope of Changes**
- Reducing the set of colors tjbot understands to those that are easily recognized via STT

This may not entirely be _necessary_, but it may make it easier to select **distinct** colors with a smaller list.