### PR TITLE
Fixing a timing issue with listen()/stopListen()

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -736,6 +736,10 @@ TJBot.prototype.stopListening = function() {
 
     // stop the mic
     this._mic.stop();
+
+    // sleep for 1 second to wait for the mic to finish closing. this seems
+    // necessary for a subsequent call to listen() to work correctly.
+    this.sleep(1000);
 }
 
 /** ------------------------------------------------------------------------ */

--- a/test/test.listen.js
+++ b/test/test.listen.js
@@ -31,24 +31,23 @@ var tjConfig = {
 var tj = new TJBot(hardware, tjConfig, credentials);
 
 // listen for speech
-console.log("listening for 5 seconds");
-
-tj.listen(function(msg) {
-    console.log("received a message");
-});
-
-setTimeout(function() {
-    console.log("timer fired, stoping listening");
-    tj.stopListening();
-}, 5000);
-
-setTimeout(function() {
-    console.log("goodbye!");
-}, 20000);
-
-setTimeout(function() {
-    console.log("timer fired, starting listening again");
+function doListen() {
+    console.log("calling listen()");
     tj.listen(function(msg) {
-        console.log("received a message");
+        if (msg.startsWith("stop")) {
+            console.log("stopping listening");
+            tj.stopListening();
+            //tj.sleep(2000);
+            console.log("calling doListen() again");
+            doListen();
+            console.log("after doListen() call");
+        } else if (msg.startsWith("exit")) {
+            console.log("exiting test");
+            process.exit();
+        }
     });
-}, 10000);
+    console.log("after listen() call");
+}
+
+doListen();
+


### PR DESCRIPTION
**Scope of Changes**
- updated listen test to call `listen()` and `stopListening()` repeatedly, so i could...
- fix a bug in `stopListening()` where subsequent calls to `listen()` would oddly fail to start listening. I don't quite understand _why_ the fix works, but it seems to work in testing.