### PR TITLE
Changed semantics of pulse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,23 +464,18 @@ tj.shine('pink');
 tj.shine('#0A2C9F');
 ```
 
-### tj.pulse(color, duration, delay)
+### tj.pulse(color, duration)
 
 Pulses the LED the given color (e.g. fades in and out to the given color).
 
 - `color` specifies the color of the pulse
-- `duration` specifies how long the pulse should last
-- `delay` specifies how long to wait in between pulses
+- `duration` specifies how long the pulse should last. TJBot will throw an error if the duration is less than 0.5 seconds or greater than 2 seconds, as pulses outside of these bounds are not very reliable.
 
-This method returns instantly, but TJBot will continue to pulse the LED until `tj.stopPulsing()` is called.
+Sample usage:
 
-### tj.isPulsing()
-
-Returns `true` if TJBot is currently pulsing the LED and `false` otherwise.
-
-### tj.stopPulsing()
-
-Stops pulsing the LED.
+```
+tj.pulse('blue', 1.0);
+```
 
 ### tj.shineColors()
 

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -202,7 +202,7 @@ TJBot.prototype._setupCamera = function() {
         horizontalFlip: this.configuration.see.camera.horizontalFlip,
         time: 1
     });
-    
+
     // versions of node-raspistill < 0.0.11 don't have the `time` option, so
     // force it in if we don't find it
     if (!this._camera.options.hasOwnProperty('time')) {
@@ -919,13 +919,16 @@ TJBot.prototype.shine = function(color) {
 /**
  * Pulse the LED a single time.
  * @param {String} color The color to pulse the LED.
- * @param {Integer} duration The duration the pulse should last (default = 1 second)
+ * @param {Integer} duration The duration the pulse should last (default = 1 second, should be between 0.5 and 3 seconds)
  */
-TJBot.prototype.pulseOnce = function(color, duration = 1.0) {
+TJBot.prototype.pulse = function(color, duration = 1.0) {
     this._assertCapability('shine');
 
     if (duration < 0.5) {
         throw new Error("TJBot does not recommend pulsing for less than 0.5 seconds.");
+    }
+    if (duration > 2.0) {
+        throw new Error("TJBot does not recommend pulsing for more than 3 seconds.");
     }
 
     // number of easing steps
@@ -981,62 +984,6 @@ TJBot.prototype.pulseOnce = function(color, duration = 1.0) {
         }
         resolve();
     });
-}
-
-/**
- * Continuously pulse the LED until stopPulse is called.
- *
- * @param {String} color The color to pulse the LED.
- * @param {Integer} duration The duration of the pulse in seconds (default = 1 second).
- * @param {Integer} delay The delay between pulses in seconds (default = 2 seconds). We recommend setting this to at least 1 second, and no less than half a second. Smaller values may cause interference with the Node.js event loop, especially when running interactively.
- */
-TJBot.prototype.pulse = function(color, duration = 1.0, delay = 2.0) {
-    this._assertCapability('shine');
-
-    if (delay < 0.5) {
-        throw new Error("TJBot does not recommend pulsing with a delay lower than 0.5 seconds.");
-    }
-
-    this._ledIsPulsing = true;
-
-    var self = this;
-
-    var doPulse = function() {
-        self.pulseOnce(color, duration, delay).then(function() {
-            if (self._ledIsPulsing) {
-                // setTimeout lets us return back to the main event loop
-                // before recursing, which helps when running tjbot
-                // interactively
-                setTimeout(function() {
-                    // make sure we didn't cancel
-                    if (self._ledIsPulsing) {
-                        return doPulse();
-                    }
-                }, 1000 * delay);
-            }
-        });
-    }
-
-    return doPulse();
-}
-
-/**
- * Is the LED pulsing?
- */
-TJBot.prototype.isPulsing = function() {
-    this._assertCapability('shine');
-
-    return this._ledIsPulsing;
-}
-
-/**
- * Stop pulsing the LED.
- */
-TJBot.prototype.stopPulsing = function() {
-    this._assertCapability('shine');
-
-    this._ledIsPulsing = false;
-    this.shine('off');
 }
 
 /**


### PR DESCRIPTION
**Scope of Changes**
- changed `pulse()` behavior to match that of `pulseOnce()` -- issuing a single pulse to the LED
- removed `pulseOnce()`, `isPulsing()`, and `stopPulsing()`

Rationale -- pulsing has been a very unreliable operation in Node.js (at least the way it was implemented). When pulsing continuously, the event loop of Node.js is blocked during the LED pulse. That meant the only time available for processing other things, such as the callback used in `tj.listen()`, was between pulses. This made for a bad user experience; the intent of `pulse()` was to show feedback that TJBot was listening, but by the nature of it's implementation, it wasn't able to listen during the `pulse()`, causing spoken input to be ignored.  Removing the stateful `pulse()` and changing it to a single issuance of a pulse (i.e. what `pulseOnce()` did), makes it a bit safer to use this method in conjunction with other methods that have callbacks.

**Note**: accepting this PR will cause a breakage in recipes that rely on the existing API (at least where pulsing is concerned). I recommend we bump TJBotLib to v1.3 to indicate the lack of backwards compatibility with the v1.2.x series.