### PR TITLE
Fix for tjbot issue https://github.com/ibmtjbot/tjbotlib/issues/31

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -659,12 +659,9 @@ TJBot.prototype.listen = function(callback) {
         if (err) {
             winston.error("the speech_to_text service returned an error.", err);
 
-            //stop tje microphone
+            //stop microphone
             self.stopListening();
             
-            // resume the microphone
-            self.resumeListening();
-
             // attempt to reconnect
             self.listen(callback);
         }

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -659,6 +659,9 @@ TJBot.prototype.listen = function(callback) {
         if (err) {
             winston.error("the speech_to_text service returned an error.", err);
 
+            //stop tje microphone
+            self.stopListening();
+            
             // resume the microphone
             self.resumeListening();
 


### PR DESCRIPTION
added self.stopListening() to the error handler inside listen method. This will allow the _mic object to be properly recreated.