### PR TITLE
Customizationid

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ var configuration = {
     listen: {
         microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
         inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
-        language: 'en-US' // see TJBot.prototype.languages.listen
+        language: 'en-US', // see TJBot.prototype.languages.listen
+        customizationId: null //specify a language customization id if available.
     },
     wave: {
         servoPin: 7 // corresponds to BCM 7 / physical PIN 26

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -1179,12 +1179,12 @@ TJBot.prototype.play = function(soundFile) {
 
   if (self.isPlaying) {
 
-    if (self.configuration.speak.queueSpeech) {
+    if (self.configuration.speak.queueSpeech || self.playerOptions.queueSpeech) {
       winston.debug(this.speechQueue.length + " items in Queue. Queing audio file with parameter ", self.playerOptions);
-      winston.verbose("You attempted to play audio while a file was playing. Queing " + soundFile);
+      winston.verbose("You attempted to play audio while ", self.playerOptions.filename, " file was playing. Queing ");
       this.speechQueue.push(self.playerOptions)
     } else {
-      winston.verbose("You attempted to play audio " + soundFile + " while a file was playing. To enable Queuing, add `speak: {queueSpeech: true}` to tjconfig ");
+      winston.verbose("You attempted to play audio file ", self.playerOptions.filename, " while a file was playing. To enable Queuing, add `speak: {queueSpeech: true}` to tjconfig ");
     }
   } else {
     self.isPlaying = true;

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -48,6 +48,10 @@ function TJBot(hardware, configuration, credentials) {
   // import configuration params
   this.configuration = Object.assign({}, TJBot.prototype.defaultConfiguration, configuration);
 
+  // set isPlaying to false
+  this.isPlaying = false;
+  this.speechQueue = []; // instantiate speech queue
+
   // set logging level
   winston.level = this.configuration.log.level;
 
@@ -150,7 +154,8 @@ TJBot.prototype.defaultConfiguration = {
     microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
     inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
     language: 'en-US', // see TJBot.prototype.languages.listen
-    customizationId: null //specify a language customization id if available.
+    customizationId: null, //specify a language customization id if available.
+    queueSpeech: false //// queue a request to play/speak if there is something already playing.
   },
   wave: {
     servoPin: 7 // corresponds to BCM 7 / physical PIN 26
@@ -159,7 +164,7 @@ TJBot.prototype.defaultConfiguration = {
     language: 'en-US', // see TJBot.prototype.languages.speak
     voice: undefined, // use a specific voice; if undefined, a voice is chosen based on robot.gender and speak.language
     speakerDeviceId: "plughw:0,0", // plugged-in USB card 1, device 0; see aplay -l for a list of playback devices
-    soundPlayer: "aplay" // 'aplay' , 'mpg123' , 'mpg321', 'afplay'
+    soundPlayer: "aplay", // 'aplay' , 'mpg123' , 'mpg321', 'afplay', 'ffplay'
   },
   see: {
     confidenceThreshold: {
@@ -669,6 +674,8 @@ TJBot.prototype.listen = function(callback) {
   if (this.configuration.listen.customizationId) recognizerParams.customization_id = this.configuration.listen.customizationId;
   this._micRecognizeStream = this._stt.createRecognizeStream(recognizerParams);
 
+  console.log(recognizerParams)
+
   // create the mic -> STT recognizer -> text stream
   this._micTextStream = this._micInputStream.pipe(this._micRecognizeStream);
   this._micTextStream.setEncoding('utf8');
@@ -1162,45 +1169,66 @@ TJBot.prototype.play = function(soundFile) {
   // capture 'this' context
   var self = this;
 
-  // pause listening while we play a sound -- using the internal
-  // method to avoid a capability check (and potential fail if the TJBot
-  // isn't configured to listen)
-  self._pauseListening();
-
   if (typeof soundFile == 'string') {
     self.playerOptions.filename = soundFile
   } else {
-    self.configuration = Object.assign({}, self.playerOptions, soundFile);
+    self.playerOptions = Object.assign({}, self.playerOptions, soundFile);
   }
 
-  return new Promise(function(resolve, reject) {
-    // if we don't have a speaker, throw an error
-    if (self._soundplayer == undefined) {
-      reject(new Error("unable to play audio, TJBot hardware doesn't include a \"speaker\""));
-      return;
+
+
+  if (self.isPlaying) {
+
+    if (self.configuration.speak.queueSpeech) {
+      winston.debug(this.speechQueue.length + " items in Queue. Queing audio file with parameter ", self.playerOptions);
+      winston.verbose("You attempted to play audio while a file was playing. Queing " + soundFile);
+      this.speechQueue.push(self.playerOptions)
+    } else {
+      winston.verbose("You attempted to play audio " + soundFile + " while a file was playing. To enable Queuing, add `speak: {queueSpeech: true}` to tjconfig ");
     }
+  } else {
+    self.isPlaying = true;
+    // pause listening while we play a sound -- using the internal
+    // method to avoid a capability check (and potential fail if the TJBot
+    // isn't configured to listen)
+    self._pauseListening();
 
-    var player = new self._soundplayer(self.playerOptions);
+    return new Promise(function(resolve, reject) {
+      // if we don't have a speaker, throw an error
+      if (self._soundplayer == undefined) {
+        reject(new Error("unable to play audio, TJBot hardware doesn't include a \"speaker\""));
+        return;
+      }
 
-    winston.debug("Playing audio with parameters: ", self.playerOptions);
+      var player = new self._soundplayer(self.playerOptions);
 
-    player.on('complete', function() {
-      winston.debug("audio playback finished");
+      winston.debug("Playing audio with parameters: ", self.playerOptions);
 
-      // resume listening
-      self._resumeListening();
+      player.on('complete', function() {
+        winston.debug("audio playback finished");
 
-      // done
-      resolve();
+        // resume listening
+        self._resumeListening();
+        self.isPlaying = false
+
+        // done
+        resolve();
+
+        //process elements in speech queue
+        if (self.speechQueue.length > 0) {
+          self.play(self.speechQueue.pop())
+        }
+
+      });
+
+      player.on('error', function(err) {
+        winston.error('Error occurred while playing audio :', err);
+      });
+
+      // play the audio
+      player.play(self.playerOptions);
     });
-
-    player.on('error', function(err) {
-      winston.error('Error occurred while playing audio :', err);
-    });
-
-    // play the audio
-    player.play(self.playerOptions);
-  });
+  }
 }
 
 /** ------------------------------------------------------------------------ */

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -41,86 +41,86 @@ const Raspistill = require('node-raspistill').Raspistill;
  * @constructor
  */
 function TJBot(hardware, configuration, credentials) {
-    if (!(this instanceof TJBot)) {
-        throw new Error('"new" keyword required to create TJBot service instances')
+  if (!(this instanceof TJBot)) {
+    throw new Error('"new" keyword required to create TJBot service instances')
+  }
+
+  // import configuration params
+  this.configuration = Object.assign({}, TJBot.prototype.defaultConfiguration, configuration);
+
+  // set logging level
+  winston.level = this.configuration.log.level;
+
+  // set up the hardware
+  if (hardware == undefined) {
+    throw new Error('must define a hardware configuration for TJBot');
+  }
+
+  hardware.forEach(function(device) {
+    switch (device) {
+      case 'camera':
+        this._setupCamera()
+        break;
+
+      case 'led':
+        this._setupLED();
+        break;
+
+      case 'microphone':
+        this._setupMicrophone();
+        break;
+
+      case 'servo':
+        this._setupServo(this.configuration.wave.servoPin);
+        break;
+
+      case 'speaker':
+        this._setupSpeaker();
+        break;
+    }
+  }, this);
+
+  // set up additional services when their credentials are specified
+  if (credentials != undefined) {
+    // > conversation
+    if (credentials.hasOwnProperty('conversation')) {
+      var creds = credentials['conversation'];
+      this._createServiceAPI('conversation', creds);
     }
 
-    // import configuration params
-    this.configuration = Object.assign({}, TJBot.prototype.defaultConfiguration, configuration);
-
-    // set logging level
-    winston.level = this.configuration.log.level;
-
-    // set up the hardware
-    if (hardware == undefined) {
-        throw new Error('must define a hardware configuration for TJBot');
+    // > language translator
+    if (credentials.hasOwnProperty('language_translator')) {
+      var creds = credentials['language_translator'];
+      this._createServiceAPI('language_translator', creds);
     }
 
-    hardware.forEach(function(device) {
-        switch (device) {
-            case 'camera':
-                this._setupCamera()
-                break;
-
-            case 'led':
-                this._setupLED();
-                break;
-
-            case 'microphone':
-                this._setupMicrophone();
-                break;
-
-            case 'servo':
-                this._setupServo(this.configuration.wave.servoPin);
-                break;
-
-            case 'speaker':
-                this._setupSpeaker();
-                break;
-        }
-    }, this);
-
-    // set up additional services when their credentials are specified
-    if (credentials != undefined) {
-        // > conversation
-        if (credentials.hasOwnProperty('conversation')) {
-            var creds = credentials['conversation'];
-            this._createServiceAPI('conversation', creds);
-        }
-
-        // > language translator
-        if (credentials.hasOwnProperty('language_translator')) {
-            var creds = credentials['language_translator'];
-            this._createServiceAPI('language_translator', creds);
-        }
-
-        // > speech to text
-        if (credentials.hasOwnProperty('speech_to_text')) {
-            var creds = credentials['speech_to_text'];
-            this._createServiceAPI('speech_to_text', creds);
-        }
-
-        // > text to speech
-        if (credentials.hasOwnProperty('text_to_speech')) {
-            var creds = credentials['text_to_speech'];
-            this._createServiceAPI('text_to_speech', creds);
-        }
-
-        // > tone analyzer
-        if (credentials.hasOwnProperty('tone_analyzer')) {
-            var creds = credentials['tone_analyzer'];
-            this._createServiceAPI('tone_analyzer', creds);
-        }
-
-        // > visual recognition
-        if (credentials.hasOwnProperty('visual_recognition')) {
-            var creds = credentials['visual_recognition'];
-            this._createServiceAPI('visual_recognition', creds);
-        }
+    // > speech to text
+    if (credentials.hasOwnProperty('speech_to_text')) {
+      var creds = credentials['speech_to_text'];
+      this._createServiceAPI('speech_to_text', creds);
     }
 
-    winston.info("Hello from TJBot! My name is " + this.configuration.robot.name + ".");
-    winston.verbose("TJBot library version " + TJBot.prototype.version);
+    // > text to speech
+    if (credentials.hasOwnProperty('text_to_speech')) {
+      var creds = credentials['text_to_speech'];
+      this._createServiceAPI('text_to_speech', creds);
+    }
+
+    // > tone analyzer
+    if (credentials.hasOwnProperty('tone_analyzer')) {
+      var creds = credentials['tone_analyzer'];
+      this._createServiceAPI('tone_analyzer', creds);
+    }
+
+    // > visual recognition
+    if (credentials.hasOwnProperty('visual_recognition')) {
+      var creds = credentials['visual_recognition'];
+      this._createServiceAPI('visual_recognition', creds);
+    }
+  }
+
+  winston.info("Hello from TJBot! My name is " + this.configuration.robot.name + ".");
+  winston.verbose("TJBot library version " + TJBot.prototype.version);
 }
 
 /**
@@ -139,38 +139,40 @@ TJBot.prototype.services = ['conversation', 'language_translator', 'speech_to_te
  * Default configuration parameters.
  */
 TJBot.prototype.defaultConfiguration = {
-    log: {
-        level: 'info' // valid levels are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'
+  log: {
+    level: 'info' // valid levels are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'
+  },
+  robot: {
+    gender: 'male', // see TJBot.prototype.genders
+    name: 'Watson'
+  },
+  listen: {
+    microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
+    inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
+    language: 'en-US', // see TJBot.prototype.languages.listen
+    customizationId: null //specify a language customization id if available.
+  },
+  wave: {
+    servoPin: 7 // corresponds to BCM 7 / physical PIN 26
+  },
+  speak: {
+    language: 'en-US', // see TJBot.prototype.languages.speak
+    voice: undefined, // use a specific voice; if undefined, a voice is chosen based on robot.gender and speak.language
+    speakerDeviceId: "plughw:0,0", // plugged-in USB card 1, device 0; see aplay -l for a list of playback devices
+    soundPlayer: "aplay" // 'aplay' , 'mpg123' , 'mpg321', 'afplay'
+  },
+  see: {
+    confidenceThreshold: {
+      object: 0.5,
+      text: 0.1
     },
-    robot: {
-        gender: 'male', // see TJBot.prototype.genders
-        name: 'Watson'
-    },
-    listen: {
-        microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
-        inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
-        language: 'en-US' // see TJBot.prototype.languages.listen
-    },
-    wave: {
-        servoPin: 7 // corresponds to BCM 7 / physical PIN 26
-    },
-    speak: {
-        language: 'en-US', // see TJBot.prototype.languages.speak
-        voice: undefined, // use a specific voice; if undefined, a voice is chosen based on robot.gender and speak.language
-        speakerDeviceId: "plughw:0,0" // plugged-in USB card 1, device 0; see aplay -l for a list of playback devices
-    },
-    see: {
-        confidenceThreshold: {
-            object: 0.5,
-            text: 0.1
-        },
-        camera: {
-            height: 720,
-            width: 960,
-            verticalFlip: false, // flips the image vertically, may need to set to 'true' if the camera is installed upside-down
-            horizontalFlip: false // flips the image horizontally, should not need to be overridden
-        }
+    camera: {
+      height: 720,
+      width: 960,
+      verticalFlip: false, // flips the image vertically, may need to set to 'true' if the camera is installed upside-down
+      horizontalFlip: false // flips the image horizontally, should not need to be overridden
     }
+  }
 };
 
 // List of all available configuration parameters
@@ -190,105 +192,105 @@ TJBot.prototype.genders = ['male', 'female'];
  * Configure the Camera.
  */
 TJBot.prototype._setupCamera = function() {
-    winston.verbose("TJBot initializing Camera");
+  winston.verbose("TJBot initializing Camera");
 
-    this._camera = new Raspistill({
-        width: this.configuration.see.camera.width,
-        height: this.configuration.see.camera.height,
-        noPreview: true,
-        encoding: 'jpg',
-        outputDir: './',
-        verticalFlip: this.configuration.see.camera.verticalFlip,
-        horizontalFlip: this.configuration.see.camera.horizontalFlip,
-        time: 1
-    });
+  this._camera = new Raspistill({
+    width: this.configuration.see.camera.width,
+    height: this.configuration.see.camera.height,
+    noPreview: true,
+    encoding: 'jpg',
+    outputDir: './',
+    verticalFlip: this.configuration.see.camera.verticalFlip,
+    horizontalFlip: this.configuration.see.camera.horizontalFlip,
+    time: 1
+  });
 
-    // versions of node-raspistill < 0.0.11 don't have the `time` option, so
-    // force it in if we don't find it
-    if (!this._camera.options.hasOwnProperty('time')) {
-        winston.silly("node-raspistill camera option for `time` not found, swizzling it in");
-        var self = this._camera;
-        self.processOptionsOriginal = self.processOptions;
-        self.processOptions = function(newOptions) {
-            var options = self.processOptionsOriginal(newOptions);
-            options.push('-t');
-            options.push('1');
-            return options;
-        }
+  // versions of node-raspistill < 0.0.11 don't have the `time` option, so
+  // force it in if we don't find it
+  if (!this._camera.options.hasOwnProperty('time')) {
+    winston.silly("node-raspistill camera option for `time` not found, swizzling it in");
+    var self = this._camera;
+    self.processOptionsOriginal = self.processOptions;
+    self.processOptions = function(newOptions) {
+      var options = self.processOptionsOriginal(newOptions);
+      options.push('-t');
+      options.push('1');
+      return options;
     }
+  }
 }
 
 /**
  * Configure the LED. The LED must be attached to the BCM 18 (PWM0) PIN.
  */
 TJBot.prototype._setupLED = function() {
-    winston.verbose("TJBot initializing LED");
+  winston.verbose("TJBot initializing LED");
 
-    var ws281x = require('rpi-ws281x-native');
+  var ws281x = require('rpi-ws281x-native');
 
-    // init with 1 LED
-    this._led = ws281x;
-    this._led.init(1);
+  // init with 1 LED
+  this._led = ws281x;
+  this._led.init(1);
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    // reset the LED before the program exits
-    process.on('SIGINT', function() {
-        self._led.reset();
-        process.nextTick(function() {
-            process.exit(0);
-        })
-    });
+  // reset the LED before the program exits
+  process.on('SIGINT', function() {
+    self._led.reset();
+    process.nextTick(function() {
+      process.exit(0);
+    })
+  });
 }
 
 /**
  * Configure the microphone for speech recognition.
  */
 TJBot.prototype._setupMicrophone = function() {
-    winston.verbose("TJBot initializing microphone");
+  winston.verbose("TJBot initializing microphone");
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    var micParams = {
-        'rate': '44100',
-        'channels': '2',
-        'debug': false,
-        'exitOnSilence': 6
-    };
+  var micParams = {
+    'rate': '44100',
+    'channels': '2',
+    'debug': false,
+    'exitOnSilence': 6
+  };
 
-    if (this.configuration.listen.microphoneDeviceId) {
-        micParams.device = this.configuration.listen.microphoneDeviceId;
-    }
+  if (this.configuration.listen.microphoneDeviceId) {
+    micParams.device = this.configuration.listen.microphoneDeviceId;
+  }
 
-    // create the microphone
-    this._mic = Mic(micParams);
+  // create the microphone
+  this._mic = Mic(micParams);
 
-    // (re-)create the mic audio stream and pipe it to STT
-    this._micInputStream = this._mic.getAudioStream();
+  // (re-)create the mic audio stream and pipe it to STT
+  this._micInputStream = this._mic.getAudioStream();
 
-    this._micInputStream.on('startComplete', function() {
-        winston.debug("microphone started");
-    });
+  this._micInputStream.on('startComplete', function() {
+    winston.debug("microphone started");
+  });
 
-    this._micInputStream.on('pauseComplete', function() {
-        winston.debug("microphone paused");
-    });
+  this._micInputStream.on('pauseComplete', function() {
+    winston.debug("microphone paused");
+  });
 
-    // log errors in the mic input stream
-    this._micInputStream.on('error', function(err) {
-        winston.error("the microphone input stream experienced an error", err);
-    });
+  // log errors in the mic input stream
+  this._micInputStream.on('error', function(err) {
+    winston.error("the microphone input stream experienced an error", err);
+  });
 
-    this._micInputStream.on('processExitComplete', function() {
-        winston.debug("microphone exit");
-    });
+  this._micInputStream.on('processExitComplete', function() {
+    winston.debug("microphone exit");
+  });
 
-    // ignore silence
-    this._micInputStream.on('silence', function() {
-        winston.silly("microphone silence");
-    });
+  // ignore silence
+  this._micInputStream.on('silence', function() {
+    winston.silly("microphone silence");
+  });
 }
 
 /**
@@ -297,21 +299,33 @@ TJBot.prototype._setupMicrophone = function() {
  * @param {Int} pin The pin number to which the servo is connected.
  */
 TJBot.prototype._setupServo = function(pin) {
-    var Gpio = require('pigpio').Gpio;
+  var Gpio = require('pigpio').Gpio;
 
-    winston.verbose("TJBot initializing servo motor on PIN " + pin);
+  winston.verbose("TJBot initializing servo motor on PIN " + pin);
 
-    this._motor = new Gpio(pin, {
-        mode: Gpio.OUTPUT
-    });
+  this._motor = new Gpio(pin, {
+    mode: Gpio.OUTPUT
+  });
 }
 
 /**
  * Configure the speaker.
  */
 TJBot.prototype._setupSpeaker = function() {
-    // lazily load the sound-play library . This lib is used as it allows specification of speakerDeviceId
-    this._soundplayer = require('sound-player');
+  // lazily load the sound-play library . This lib is used as it allows specification of speakerDeviceId
+
+  this._soundplayer = require('sound-player')
+
+  // initialize soundplayer lib
+  this.playerOptions = {
+    filename: "",
+    gain: 100,
+    debug: false,
+    player: this.configuration.speak.soundPlayer, // "afplay" "aplay" "mpg123" "mpg321"
+    device: this.configuration.speak.speakerDeviceId
+  }
+
+  //this._soundplayer = new soundplayer(this.playerOptions);
 }
 
 /**
@@ -321,120 +335,121 @@ TJBot.prototype._setupSpeaker = function() {
  * @param {Object} credentials The credentials, with keys for '{service}_username' and '{service}_password'.
  */
 TJBot.prototype._createServiceAPI = function(service, credentials) {
-    winston.verbose("TJBot initializing " + service + " service");
+  winston.verbose("TJBot initializing " + service + " service");
 
-    assert(credentials, "no credentials found for the " + service + " service");
+  assert(credentials, "no credentials found for the " + service + " service");
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    switch (service) {
-        case 'conversation':
-            assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
-            assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
+  switch (service) {
+    case 'conversation':
+      assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
+      assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
 
-            if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
-                credentials['version_date'] = "2017-02-03";
-            }
+      if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
+        credentials['version_date'] = "2017-02-03";
+      }
 
-            var ConversationV1 = require('watson-developer-cloud/conversation/v1');
-            this._conversation = new ConversationV1({
-                username: credentials['username'],
-                password: credentials['password'],
-                version: 'v1',
-                version_date: credentials['version_date']
-            });
+      var ConversationV1 = require('watson-developer-cloud/conversation/v1');
+      this._conversation = new ConversationV1({
+        username: credentials['username'],
+        password: credentials['password'],
+        version: 'v1',
+        version_date: credentials['version_date']
+      });
 
-            // cache of conversation contexts. hash key is the workspaceId of the conversation,
-            // allowing TJ to run multiple conversations at once.
-            this._conversationContext = {};
-            break;
+      // cache of conversation contexts. hash key is the workspaceId of the conversation,
+      // allowing TJ to run multiple conversations at once.
+      this._conversationContext = {};
+      break;
 
-        case 'language_translator':
-            assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
-            assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
+    case 'language_translator':
+      assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
+      assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
 
-            var LanguageTranslatorV2 = require('watson-developer-cloud/language-translator/v2');
-            this._languageTranslator = new LanguageTranslatorV2({
-                username: credentials['username'],
-                password: credentials['password'],
-                version: 'v2',
-                url: 'https://gateway.watsonplatform.net/language-translator/api/'
-            });
+      var LanguageTranslatorV2 = require('watson-developer-cloud/language-translator/v2');
+      this._languageTranslator = new LanguageTranslatorV2({
+        username: credentials['username'],
+        password: credentials['password'],
+        version: 'v2',
+        url: 'https://gateway.watsonplatform.net/language-translator/api/'
+      });
 
-            // load the list of language models
-            this._loadLanguageTranslations().then(function(translations) {
-                self._translations = translations;
-            });
-            break;
+      // load the list of language models
+      this._loadLanguageTranslations().then(function(translations) {
+        self._translations = translations;
+      });
+      break;
 
-        case 'speech_to_text':
-            assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
-            assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
+    case 'speech_to_text':
+      assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
+      assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
 
-            var SpeechToTextV1 = require('watson-developer-cloud/speech-to-text/v1');
-            this._stt = new SpeechToTextV1({
-                username: credentials['username'],
-                password: credentials['password'],
-                version: 'v1'
-            });
-            break;
+      var SpeechToTextV1 = require('watson-developer-cloud/speech-to-text/v1');
+      this._stt = new SpeechToTextV1({
+        username: credentials['username'],
+        password: credentials['password'],
+        version: 'v1'
+      });
 
-        case 'text_to_speech':
-            assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
-            assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
+      break;
 
-            var TextToSpeechV1 = require('watson-developer-cloud/text-to-speech/v1');
-            this._tts = new TextToSpeechV1({
-                username: credentials['username'],
-                password: credentials['password'],
-                version: 'v1'
-            });
+    case 'text_to_speech':
+      assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
+      assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
 
-            this._tts.voices(null, function(error, data) {
-                if (error) {
-                    winston.error("unable to retrieve TTS voices", error);
-                    self._ttsVoices = [];
-                } else {
-                    self._ttsVoices = data.voices;
-                }
-            });
-            break;
+      var TextToSpeechV1 = require('watson-developer-cloud/text-to-speech/v1');
+      this._tts = new TextToSpeechV1({
+        username: credentials['username'],
+        password: credentials['password'],
+        version: 'v1'
+      });
 
-        case 'tone_analyzer':
-            assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
-            assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
+      this._tts.voices(null, function(error, data) {
+        if (error) {
+          winston.error("unable to retrieve TTS voices", error);
+          self._ttsVoices = [];
+        } else {
+          self._ttsVoices = data.voices;
+        }
+      });
+      break;
 
-            if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
-                credentials['version_date'] = "2016-05-19";
-            }
+    case 'tone_analyzer':
+      assert(credentials.hasOwnProperty('username'), "credentials for the " + service + " service missing 'username'");
+      assert(credentials.hasOwnProperty('password'), "credentials for the " + service + " service missing 'password'");
 
-            var ToneAnalyzerV3 = require('watson-developer-cloud/tone-analyzer/v3');
-            this._toneAnalyzer = new ToneAnalyzerV3({
-                username: credentials['username'],
-                password: credentials['password'],
-                version: 'v3',
-                version_date: credentials['version_date']
-            });
-            break;
+      if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
+        credentials['version_date'] = "2016-05-19";
+      }
 
-        case 'visual_recognition':
-            assert(credentials.hasOwnProperty('api_key'), "credentials for the " + service + " service missing 'api_key'");
+      var ToneAnalyzerV3 = require('watson-developer-cloud/tone-analyzer/v3');
+      this._toneAnalyzer = new ToneAnalyzerV3({
+        username: credentials['username'],
+        password: credentials['password'],
+        version: 'v3',
+        version_date: credentials['version_date']
+      });
+      break;
 
-            if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
-                credentials['version_date'] = "2016-05-19";
-            }
+    case 'visual_recognition':
+      assert(credentials.hasOwnProperty('api_key'), "credentials for the " + service + " service missing 'api_key'");
 
-            var VisualRecognitionV3 = require('watson-developer-cloud/visual-recognition/v3');
-            this._visualRecognition = new VisualRecognitionV3({
-                api_key: credentials['api_key'],
-                version_date: credentials['version_date']
-            });
-            break;
+      if (credentials['version_date'] == undefined || credentials['version_date'] == "") {
+        credentials['version_date'] = "2016-05-19";
+      }
 
-        default:
-            break;
-    }
+      var VisualRecognitionV3 = require('watson-developer-cloud/visual-recognition/v3');
+      this._visualRecognition = new VisualRecognitionV3({
+        api_key: credentials['api_key'],
+        version_date: credentials['version_date']
+      });
+      break;
+
+    default:
+      break;
+  }
 }
 
 /**
@@ -443,86 +458,86 @@ TJBot.prototype._createServiceAPI = function(service, credentials) {
  * @param {String} capability The capability assert (see TJBot.prototype.capabilities).
  */
 TJBot.prototype._assertCapability = function(capability) {
-    switch (capability) {
-        case 'analyze_tone':
-            if (!this._toneAnalyzer) {
-                throw new Error(
-                    'TJBot is not configured to analyze tone. ' +
-                    'Please check that you included credentials for the Watson Tone Analyzer service.');
-            }
-            break;
+  switch (capability) {
+    case 'analyze_tone':
+      if (!this._toneAnalyzer) {
+        throw new Error(
+          'TJBot is not configured to analyze tone. ' +
+          'Please check that you included credentials for the Watson Tone Analyzer service.');
+      }
+      break;
 
-        case 'converse':
-            if (!this._conversation) {
-                throw new Error(
-                    'TJBot is not configured to converse. ' +
-                    'Please check that you included credentials for the Watson "conversation" service in the TJBot constructor.');
-            }
-            break;
+    case 'converse':
+      if (!this._conversation) {
+        throw new Error(
+          'TJBot is not configured to converse. ' +
+          'Please check that you included credentials for the Watson "conversation" service in the TJBot constructor.');
+      }
+      break;
 
-        case 'listen':
-            if (!this._mic) {
-                throw new Error(
-                    'TJBot is not configured to listen. ' +
-                    'Please check you included the "microphone" hardware in the TJBot constructor.');
-            }
-            if (!this._stt) {
-                throw new Error(
-                    'TJBot is not configured to listen. ' +
-                    'Please check that you included credentials for the Watson "speech_to_text" service in the TJBot constructor.');
-            }
-            break;
+    case 'listen':
+      if (!this._mic) {
+        throw new Error(
+          'TJBot is not configured to listen. ' +
+          'Please check you included the "microphone" hardware in the TJBot constructor.');
+      }
+      if (!this._stt) {
+        throw new Error(
+          'TJBot is not configured to listen. ' +
+          'Please check that you included credentials for the Watson "speech_to_text" service in the TJBot constructor.');
+      }
+      break;
 
-        case 'see':
-            if (!this._camera) {
-                throw new Error(
-                    'TJBot is not configured to see. ' +
-                    'Please check you included the "camera" hardware in the TJBot constructor.');
-            }
-            if (!this._visualRecognition) {
-                throw new Error(
-                    'TJBot is not configured to see. ' +
-                    'Please check you included credentials for the Watson "visual_recognition" service in the TJBot constructor.');
-            }
-            break;
+    case 'see':
+      if (!this._camera) {
+        throw new Error(
+          'TJBot is not configured to see. ' +
+          'Please check you included the "camera" hardware in the TJBot constructor.');
+      }
+      if (!this._visualRecognition) {
+        throw new Error(
+          'TJBot is not configured to see. ' +
+          'Please check you included credentials for the Watson "visual_recognition" service in the TJBot constructor.');
+      }
+      break;
 
-        case 'shine':
-            if (!this._led) {
-                throw new Error(
-                    'TJBot is not configured with an LED. ' +
-                    'Please check you included the "led" hardware in the TJBot constructor.');
-            }
-            break;
+    case 'shine':
+      if (!this._led) {
+        throw new Error(
+          'TJBot is not configured with an LED. ' +
+          'Please check you included the "led" hardware in the TJBot constructor.');
+      }
+      break;
 
-        case 'speak':
-            if (!this._soundplayer) {
-                throw new Error(
-                    'TJBot is not configured to speak. ' +
-                    'Please check you incldued the "speaker" hardware in the TJBot constructor.');
-            }
-            if (!this._tts) {
-                throw new Error(
-                    'TJBot is not configured to speak. ' +
-                    'Please check you included credentials for the Watson "text_to_speech" service in the TJBot constructor.');
-            }
-            break;
+    case 'speak':
+      if (!this._soundplayer) {
+        throw new Error(
+          'TJBot is not configured to speak. ' +
+          'Please check you incldued the "speaker" hardware in the TJBot constructor.');
+      }
+      if (!this._tts) {
+        throw new Error(
+          'TJBot is not configured to speak. ' +
+          'Please check you included credentials for the Watson "text_to_speech" service in the TJBot constructor.');
+      }
+      break;
 
-        case 'translate':
-            if (!this._languageTranslator) {
-                throw new Error(
-                    'TJBot is not configured to translate. ' +
-                    'Please check you included credentials for the Watson "language_translator" service in the TJBot constructor.');
-            }
-            break;
+    case 'translate':
+      if (!this._languageTranslator) {
+        throw new Error(
+          'TJBot is not configured to translate. ' +
+          'Please check you included credentials for the Watson "language_translator" service in the TJBot constructor.');
+      }
+      break;
 
-        case 'wave':
-            if (!this._motor) {
-                throw new Error(
-                    'TJBot is not configured with an arm. ' +
-                    'Please check you included the "servo" hardware in the TJBot constructor.');
-            }
-            break;
-    }
+    case 'wave':
+      if (!this._motor) {
+        throw new Error(
+          'TJBot is not configured with an arm. ' +
+          'Please check you included the "servo" hardware in the TJBot constructor.');
+      }
+      break;
+  }
 }
 
 /** ------------------------------------------------------------------------ */
@@ -535,8 +550,8 @@ TJBot.prototype._assertCapability = function(capability) {
  * @param {Int} msec Number of milliseconds to sleep for (1000 msec == 1 sec).
  */
 TJBot.prototype.sleep = function(msec) {
-    var usec = msec * 1000;
-    sleep.usleep(usec);
+  var usec = msec * 1000;
+  sleep.usleep(usec);
 }
 
 /** ------------------------------------------------------------------------ */
@@ -549,22 +564,22 @@ TJBot.prototype.sleep = function(msec) {
  * @param {String} text The text to analyze.
  */
 TJBot.prototype.analyzeTone = function(text) {
-    this._assertCapability('analyze_tone');
+  this._assertCapability('analyze_tone');
 
-    var self = this;
-    return new Promise(function(resolve, reject) {
-        var params = {
-            text: text
-        };
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    var params = {
+      text: text
+    };
 
-        self._toneAnalyzer.tone(params, function(err, tone) {
-            if (err) {
-                winston.error("the tone_analyzer service returned an error.", err);
-            } else {
-                resolve(tone);
-            }
-        });
+    self._toneAnalyzer.tone(params, function(err, tone) {
+      if (err) {
+        winston.error("the tone_analyzer service returned an error.", err);
+      } else {
+        resolve(tone);
+      }
     });
+  });
 }
 
 /** ------------------------------------------------------------------------ */
@@ -580,47 +595,47 @@ TJBot.prototype.analyzeTone = function(text) {
  * Returns a conversation api response object
  */
 TJBot.prototype.converse = function(workspaceId, message, callback) {
-    this._assertCapability('converse');
+  this._assertCapability('converse');
 
-    // save the conversational context
-    if (this._conversationContext[workspaceId] == undefined) {
-        this._conversationContext[workspaceId] = {};
+  // save the conversational context
+  if (this._conversationContext[workspaceId] == undefined) {
+    this._conversationContext[workspaceId] = {};
+  }
+
+  var context = this._conversationContext[workspaceId];
+
+  // define the conversational turn
+  var turn = {
+    workspace_id: workspaceId,
+    input: {
+      'text': message
+    },
+    context: context
+  };
+
+  // capture context
+  var self = this;
+
+  // send to Conversation service
+  this._conversation.message(turn, function(err, conversationResponseObject) {
+    if (err) {
+      winston.error("the conversation service returned an error.", err);
+    } else {
+      // cache the returned context
+      self._conversationContext[workspaceId] = conversationResponseObject.context;
+
+      // return the response object and response text
+      var responseText = conversationResponseObject.output.text.length > 0 ? conversationResponseObject.output.text[0] : "";
+      var response = {
+        "object": conversationResponseObject,
+        "description": responseText
+      };
+
+      // log response text
+      winston.verbose("TJBot response from conversation id " + workspaceId + " " + responseText + " :");
+      callback(response);
     }
-
-    var context = this._conversationContext[workspaceId];
-
-    // define the conversational turn
-    var turn = {
-        workspace_id: workspaceId,
-        input: {
-            'text': message
-        },
-        context: context
-    };
-
-    // capture context
-    var self = this;
-
-    // send to Conversation service
-    this._conversation.message(turn, function(err, conversationResponseObject) {
-        if (err) {
-            winston.error("the conversation service returned an error.", err);
-        } else {
-            // cache the returned context
-            self._conversationContext[workspaceId] = conversationResponseObject.context;
-
-            // return the response object and response text
-            var responseText = conversationResponseObject.output.text.length > 0 ? conversationResponseObject.output.text[0] : "";
-            var response = {
-                "object": conversationResponseObject,
-                "description": responseText
-            };
-
-            // log response text
-            winston.verbose("TJBot response from conversation id " + workspaceId + " " + responseText + " :");
-            callback(response);
-        }
-    });
+  });
 }
 
 /** ------------------------------------------------------------------------ */
@@ -631,64 +646,68 @@ TJBot.prototype.converse = function(workspaceId, message, callback) {
  * Listen for spoken utterances.
  */
 TJBot.prototype.listen = function(callback) {
-    // make sure we can listen
-    this._assertCapability('listen');
+  // make sure we can listen
+  this._assertCapability('listen');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    // (re)initialize the microphone because if stopListening() was called, we don't seem to
-    // be able to re-use the microphone twice
-    this._setupMicrophone();
+  // (re)initialize the microphone because if stopListening() was called, we don't seem to
+  // be able to re-use the microphone twice
+  this._setupMicrophone();
 
-    // create the microphone -> STT recognizer stream
-    // see this page for additional documentation on the STT configuration parameters:
-    // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
-    this._micRecognizeStream = this._stt.createRecognizeStream({
-        content_type: 'audio/l16; rate=44100; channels=2',
-        inactivity_timeout: this.configuration.listen.inactivityTimeout,
-        model: this.configuration.listen.language + "_BroadbandModel"
-    });
+  // create the microphone -> STT recognizer stream
+  // see this page for additional documentation on the STT configuration parameters:
+  // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
 
-    // create the mic -> STT recognizer -> text stream
-    this._micTextStream = this._micInputStream.pipe(this._micRecognizeStream);
-    this._micTextStream.setEncoding('utf8');
+  var recognizerParams = {
+    content_type: 'audio/l16; rate=44100; channels=2',
+    inactivity_timeout: this.configuration.listen.inactivityTimeout,
+    model: this.configuration.listen.language + "_BroadbandModel"
+  }
 
-    // handle errors in the text stream
-    this._micTextStream.on('error', function(err) {
-        if (err) {
-            winston.error("the speech_to_text service returned an error.", err);
+  if (this.configuration.listen.customizationId) recognizerParams.customization_id = this.configuration.listen.customizationId;
+  this._micRecognizeStream = this._stt.createRecognizeStream(recognizerParams);
 
-            //stop microphone
-            self.stopListening();
-            
-            // attempt to reconnect
-            self.listen(callback);
-        }
-    });
+  // create the mic -> STT recognizer -> text stream
+  this._micTextStream = this._micInputStream.pipe(this._micRecognizeStream);
+  this._micTextStream.setEncoding('utf8');
 
-    // deliver STT data to the callback
-    this._micTextStream.on('data', function(transcript) {
-        winston.info("TJBot heard: " + transcript);
+  // handle errors in the text stream
+  this._micTextStream.on('error', function(err) {
+    if (err) {
+      winston.error("the speech_to_text service returned an error.", err);
 
-        if (callback != undefined) {
-            callback(transcript);
-        }
-    });
+      //stop microphone
+      self.stopListening();
 
-    // start the microphone
-    this._mic.start();
+      // attempt to reconnect
+      self.listen(callback);
+    }
+  });
+
+  // deliver STT data to the callback
+  this._micTextStream.on('data', function(transcript) {
+    winston.info("TJBot heard: " + transcript);
+
+    if (callback != undefined) {
+      callback(transcript);
+    }
+  });
+
+  // start the microphone
+  this._mic.start();
 }
 
 /**
  * Pause listening for spoken utterances
  */
 TJBot.prototype.pauseListening = function() {
-    // make sure we can listen
-    this._assertCapability('listen');
+  // make sure we can listen
+  this._assertCapability('listen');
 
-    // pause the mic
-    this._pauseListening();
+  // pause the mic
+  this._pauseListening();
 }
 
 /**
@@ -697,21 +716,21 @@ TJBot.prototype.pauseListening = function() {
  * the 'listen' capability.
  */
 TJBot.prototype._pauseListening = function() {
-    if (this._mic != undefined) {
-        winston.debug("listening paused");
-        this._mic.pause();
-    }
+  if (this._mic != undefined) {
+    winston.debug("listening paused");
+    this._mic.pause();
+  }
 }
 
 /**
  * Resume listening for spoken utterances
  */
 TJBot.prototype.resumeListening = function() {
-    // make sure we can listen
-    this._assertCapability('listen');
+  // make sure we can listen
+  this._assertCapability('listen');
 
-    // resume the mic
-    this._resumeListening();
+  // resume the mic
+  this._resumeListening();
 }
 
 /**
@@ -720,27 +739,27 @@ TJBot.prototype.resumeListening = function() {
  * the 'listen' capability.
  */
 TJBot.prototype._resumeListening = function() {
-    if (this._mic != undefined) {
-        winston.debug("listening resumed");
-        this._mic.resume();
-    }
+  if (this._mic != undefined) {
+    winston.debug("listening resumed");
+    this._mic.resume();
+  }
 }
 
 /**
  * Stop listening for spoken utterances
  */
 TJBot.prototype.stopListening = function() {
-    // make sure we can listen
-    this._assertCapability('listen');
+  // make sure we can listen
+  this._assertCapability('listen');
 
-    winston.debug("listening stopped");
+  winston.debug("listening stopped");
 
-    // stop the mic
-    this._mic.stop();
+  // stop the mic
+  this._mic.stop();
 
-    // sleep for 1 second to wait for the mic to finish closing. this seems
-    // necessary for a subsequent call to listen() to work correctly.
-    this.sleep(1000);
+  // sleep for 1 second to wait for the mic to finish closing. this seems
+  // necessary for a subsequent call to listen() to work correctly.
+  this.sleep(1000);
 }
 
 /** ------------------------------------------------------------------------ */
@@ -755,44 +774,44 @@ TJBot.prototype.stopListening = function() {
  * return object.
  */
 TJBot.prototype.see = function() {
-    this._assertCapability('see');
+  this._assertCapability('see');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        winston.verbose("TJBot taking a photo");
-        self.takePhoto().then(function(filePath) {
-            resolve(self.recognizeObjectsInPhoto(filePath))
-        });
+  return new Promise(function(resolve, reject) {
+    winston.verbose("TJBot taking a photo");
+    self.takePhoto().then(function(filePath) {
+      resolve(self.recognizeObjectsInPhoto(filePath))
     });
+  });
 }
 
 /*
 Describe photo by sending it to the Watson Visual Recognition Service.
  */
 TJBot.prototype.recognizeObjectsInPhoto = function(filePath) {
-    this._assertCapability('see');
+  this._assertCapability('see');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        winston.debug("sending image to Watson Visual Recognition");
-        var params = {
-            images_file: fs.createReadStream(filePath),
-            threshold: self.configuration.see.confidenceThreshold.object
-        };
+  return new Promise(function(resolve, reject) {
+    winston.debug("sending image to Watson Visual Recognition");
+    var params = {
+      images_file: fs.createReadStream(filePath),
+      threshold: self.configuration.see.confidenceThreshold.object
+    };
 
-        self._visualRecognition.classify(params, function(err, response) {
-            if (err) {
-                reject(err);
-            } else {
-                var result = response.images[0].classifiers[0].classes;
-                resolve(result);
-            }
-        });
+    self._visualRecognition.classify(params, function(err, response) {
+      if (err) {
+        reject(err);
+      } else {
+        var result = response.images[0].classifiers[0].classes;
+        resolve(result);
+      }
     });
+  });
 }
 
 /**
@@ -803,42 +822,42 @@ TJBot.prototype.recognizeObjectsInPhoto = function(filePath) {
  * return object.
  */
 TJBot.prototype.read = function() {
-    this._assertCapability('see');
+  this._assertCapability('see');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        self.takePhoto().then(function(filePath) {
-            resolve(self.recognizeTextInPhoto(filePath))
-        });
+  return new Promise(function(resolve, reject) {
+    self.takePhoto().then(function(filePath) {
+      resolve(self.recognizeTextInPhoto(filePath))
     });
+  });
 }
 
 /*
 Recognize text in photo by sending it to the Watson Visual Recognition Service.
  */
 TJBot.prototype.recognizeTextInPhoto = function(filePath) {
-    this._assertCapability('see');
+  this._assertCapability('see');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        winston.debug("sending image to Watson Visual Recognition to recognize text.");
-        var params = {
-            images_file: fs.createReadStream(filePath),
-            threshold: self.configuration.see.confidenceThreshold.text
-        };
+  return new Promise(function(resolve, reject) {
+    winston.debug("sending image to Watson Visual Recognition to recognize text.");
+    var params = {
+      images_file: fs.createReadStream(filePath),
+      threshold: self.configuration.see.confidenceThreshold.text
+    };
 
-        self._visualRecognition.recognizeText(params, function(err, response) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(response);
-            }
-        });
+    self._visualRecognition.recognizeText(params, function(err, response) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(response);
+      }
     });
+  });
 }
 
 /**
@@ -849,44 +868,44 @@ TJBot.prototype.recognizeTextInPhoto = function(filePath) {
  * Returns the photo data in a Buffer.
  */
 TJBot.prototype.takePhoto = function(filePath) {
-    this._assertCapability('see');
+  this._assertCapability('see');
 
-    // capture 'this' context
-    var self = this;
-    var path = "";
-    var name = "";
+  // capture 'this' context
+  var self = this;
+  var path = "";
+  var name = "";
 
-    // if no file path provided, save to temp location
-    if (filePath == null || filePath == "") {
-        filePath = temp.path({
-            prefix: 'tjbot'
-        });
-    };
-
-    winston.debug("capturing image at path: " + filePath);
-    path = filePath.lastIndexOf("/") > 0 ? filePath.substring(0, filePath.lastIndexOf("/")) : ""; // save to current dir if no directory provided.
-    name = filePath.substring(filePath.lastIndexOf("/") + 1);
-    name = name.replace(".jpg", ""); // the node raspistill lib already adds encoding .jpg to file.
-
-    // set the configuration options, which may have changed since the camera was initialized
-    this._camera.setOptions({
-        outputDir: path,
-        fileName: name,
-        width: this.configuration.see.camera.width,
-        height: this.configuration.see.camera.height,
-        verticalFlip: this.configuration.see.camera.verticalFlip,
-        horizontalFlip: this.configuration.see.camera.horizontalFlip
+  // if no file path provided, save to temp location
+  if (filePath == null || filePath == "") {
+    filePath = temp.path({
+      prefix: 'tjbot'
     });
+  };
 
-    return new Promise(function(resolve, reject) {
-        self._camera.takePhoto().then(function(photobuffer) {
-            var returnPath = path == "" ? (name + "." + self._camera.getOptions().encoding) : (path + "/" + name + "." + self._camera.getOptions().encoding);
-            resolve(returnPath);
-        }).catch(function(error) {
-            winston.error('Error taking picture.', error);
-            reject(error);
-        });
-    })
+  winston.debug("capturing image at path: " + filePath);
+  path = filePath.lastIndexOf("/") > 0 ? filePath.substring(0, filePath.lastIndexOf("/")) : ""; // save to current dir if no directory provided.
+  name = filePath.substring(filePath.lastIndexOf("/") + 1);
+  name = name.replace(".jpg", ""); // the node raspistill lib already adds encoding .jpg to file.
+
+  // set the configuration options, which may have changed since the camera was initialized
+  this._camera.setOptions({
+    outputDir: path,
+    fileName: name,
+    width: this.configuration.see.camera.width,
+    height: this.configuration.see.camera.height,
+    verticalFlip: this.configuration.see.camera.verticalFlip,
+    horizontalFlip: this.configuration.see.camera.horizontalFlip
+  });
+
+  return new Promise(function(resolve, reject) {
+    self._camera.takePhoto().then(function(photobuffer) {
+      var returnPath = path == "" ? (name + "." + self._camera.getOptions().encoding) : (path + "/" + name + "." + self._camera.getOptions().encoding);
+      resolve(returnPath);
+    }).catch(function(error) {
+      winston.error('Error taking picture.', error);
+      reject(error);
+    });
+  })
 }
 
 /** ------------------------------------------------------------------------ */
@@ -899,21 +918,21 @@ TJBot.prototype.takePhoto = function(filePath) {
  * @param {String} color The color to use. Must be interpretable by TJBot.prototype._normalizeColor.
  */
 TJBot.prototype.shine = function(color) {
-    this._assertCapability('shine');
+  this._assertCapability('shine');
 
-    // convert to rgb
-    var rgb = this._normalizeColor(color);
+  // convert to rgb
+  var rgb = this._normalizeColor(color);
 
-    // convert hex to the 0xGGRRBB format for the LED
-    var grb = "0x" + rgb[3] + rgb[4] + rgb[1] + rgb[2] + rgb[5] + rgb[6];
+  // convert hex to the 0xGGRRBB format for the LED
+  var grb = "0x" + rgb[3] + rgb[4] + rgb[1] + rgb[2] + rgb[5] + rgb[6];
 
-    // shine!
-    winston.verbose("TJBot shining my LED to RGB color " + rgb);
+  // shine!
+  winston.verbose("TJBot shining my LED to RGB color " + rgb);
 
-    // set the LED color
-    var colors = new Uint32Array(1);
-    colors[0] = parseInt(grb);
-    this._led.render(colors);
+  // set the LED color
+  var colors = new Uint32Array(1);
+  colors[0] = parseInt(grb);
+  this._led.render(colors);
 }
 
 /**
@@ -922,92 +941,92 @@ TJBot.prototype.shine = function(color) {
  * @param {Integer} duration The duration the pulse should last (default = 1 second, should be between 0.5 and 3 seconds)
  */
 TJBot.prototype.pulse = function(color, duration = 1.0) {
-    this._assertCapability('shine');
+  this._assertCapability('shine');
 
-    if (duration < 0.5) {
-        throw new Error("TJBot does not recommend pulsing for less than 0.5 seconds.");
+  if (duration < 0.5) {
+    throw new Error("TJBot does not recommend pulsing for less than 0.5 seconds.");
+  }
+  if (duration > 2.0) {
+    throw new Error("TJBot does not recommend pulsing for more than 3 seconds.");
+  }
+
+  // number of easing steps
+  var numSteps = 20;
+
+  // quadratic in-out easing
+  var easeInOutQuad = function(t, b, c, d) {
+    if ((t /= d / 2) < 1) return c / 2 * t * t + b;
+    return -c / 2 * ((--t) * (t - 2) - 1) + b;
+  }
+
+  var ease = [];
+  for (var i = 0; i < numSteps; i++) {
+    ease.push(i);
+  }
+
+  ease = ease.map(function(x, i) {
+    return easeInOutQuad(i, 0, 1, ease.length);
+  });
+
+  // normalize to 'duration' msec
+  ease = ease.map(function(x) {
+    return Math.round(x * duration * 1000)
+  });
+
+  // convert to deltas
+  var easeDelays = [];
+  for (var i = 0; i < ease.length - 1; i++) {
+    easeDelays[i] = ease[i + 1] - ease[i];
+  }
+
+  // color ramp
+  var rgb = this._normalizeColor(color).slice(1); // remove the #
+  var hex = new cm.HexRgb(rgb);
+
+  var colorRamp = [];
+  for (var i = 0; i < numSteps / 2; i++) {
+    var l = 0.0 + (i / (numSteps / 2)) * 0.5;
+    colorRamp[i] = hex.toHsl().lightness(l).toRgb().toHexString().replace('#', '0x');
+  }
+
+  // capture context
+  var self = this;
+
+  // perform the ease
+  return new Promise(function(resolve, reject) {
+    for (var i = 0; i < easeDelays.length; i++) {
+      var color = i < colorRamp.length ?
+        colorRamp[i] :
+        colorRamp[colorRamp.length - 1 - (i - colorRamp.length) - 1];
+      self.shine(color);
+      self.sleep(easeDelays[i]);
     }
-    if (duration > 2.0) {
-        throw new Error("TJBot does not recommend pulsing for more than 3 seconds.");
-    }
-
-    // number of easing steps
-    var numSteps = 20;
-
-    // quadratic in-out easing
-    var easeInOutQuad = function(t, b, c, d) {
-        if ((t /= d / 2) < 1) return c / 2 * t * t + b;
-        return -c / 2 * ((--t) * (t - 2) - 1) + b;
-    }
-
-    var ease = [];
-    for (var i = 0; i < numSteps; i++) {
-        ease.push(i);
-    }
-
-    ease = ease.map(function(x, i) {
-        return easeInOutQuad(i, 0, 1, ease.length);
-    });
-
-    // normalize to 'duration' msec
-    ease = ease.map(function(x) {
-        return Math.round(x * duration * 1000)
-    });
-
-    // convert to deltas
-    var easeDelays = [];
-    for (var i = 0; i < ease.length - 1; i++) {
-        easeDelays[i] = ease[i + 1] - ease[i];
-    }
-
-    // color ramp
-    var rgb = this._normalizeColor(color).slice(1); // remove the #
-    var hex = new cm.HexRgb(rgb);
-
-    var colorRamp = [];
-    for (var i = 0; i < numSteps / 2; i++) {
-        var l = 0.0 + (i / (numSteps / 2)) * 0.5;
-        colorRamp[i] = hex.toHsl().lightness(l).toRgb().toHexString().replace('#', '0x');
-    }
-
-    // capture context
-    var self = this;
-
-    // perform the ease
-    return new Promise(function(resolve, reject) {
-        for (var i = 0; i < easeDelays.length; i++) {
-            var color = i < colorRamp.length ?
-                colorRamp[i] :
-                colorRamp[colorRamp.length - 1 - (i - colorRamp.length) - 1];
-            self.shine(color);
-            self.sleep(easeDelays[i]);
-        }
-        resolve();
-    });
+    resolve();
+  });
 }
 
 /**
  * Get the list of colors recognized by TJBot.
  */
 TJBot.prototype.shineColors = function() {
-    this._assertCapability('shine');
+  this._assertCapability('shine');
 
-    return colorToHex.all().map(function(elt, i, array) {
-        return elt['name'];
-    });
+  return colorToHex.all().map(function(elt, i, array) {
+    return elt['name'];
+  });
 }
 
 /**
  * Get a random color.
  */
 TJBot.prototype.randomColor = function() {
-    this._assertCapability('shine');
+  this._assertCapability('shine');
 
-    var colors = this.shineColors();
-    var randIdx = Math.floor(Math.random() * colors.length);
-    var randColor = colors[randIdx];
+  var colors = this.shineColors();
+  var randIdx = Math.floor(Math.random() * colors.length);
+  var randColor = colors[randIdx];
 
-    return randColor;
+  return randColor;
 }
 
 /**
@@ -1016,55 +1035,55 @@ TJBot.prototype.randomColor = function() {
  * @param {String} color The color to normalize. May be a hex number (e.g. "0xF12AC4", "11FF22", "#AABB24"), "on", "off", or "random", or a named color as interpreted by the `colornames` package. Hex numbers follow an RRGGBB format.
  */
 TJBot.prototype._normalizeColor = function(color) {
-    // assume undefined == "off"
-    if (color == undefined) {
-        color = "off";
-    }
+  // assume undefined == "off"
+  if (color == undefined) {
+    color = "off";
+  }
 
-    // is this "on" or "off"?
-    if (color == "on") {
-        color = "FFFFFF";
-    } else if (color == "off") {
-        color = "000000";
-    } else if (color == "random") {
-        color = this.randomColor();
-    }
+  // is this "on" or "off"?
+  if (color == "on") {
+    color = "FFFFFF";
+  } else if (color == "off") {
+    color = "000000";
+  } else if (color == "random") {
+    color = this.randomColor();
+  }
 
-    // strip prefixes if they are present
-    if (color.startsWith('0x')) {
-        color = color.slice(2);
-    }
+  // strip prefixes if they are present
+  if (color.startsWith('0x')) {
+    color = color.slice(2);
+  }
 
-    if (color.startsWith('#')) {
-        color = color.slice(1);
-    }
+  if (color.startsWith('#')) {
+    color = color.slice(1);
+  }
 
-    // is this a hex number or a named color?
-    var isHex = /(^[0-9A-F]{6}$)|(^[0-9A-F]{3}$)/i;
-    var rgb = undefined;
+  // is this a hex number or a named color?
+  var isHex = /(^[0-9A-F]{6}$)|(^[0-9A-F]{3}$)/i;
+  var rgb = undefined;
 
-    if (!isHex.test(color)) {
-        rgb = colorToHex(color);
-    } else {
-        rgb = color;
-    }
+  if (!isHex.test(color)) {
+    rgb = colorToHex(color);
+  } else {
+    rgb = color;
+  }
 
-    // did we get something back?
-    if (rgb == undefined) {
-        throw new Error('TJBot did not understand the specified color "' + color + '"');
-    }
+  // did we get something back?
+  if (rgb == undefined) {
+    throw new Error('TJBot did not understand the specified color "' + color + '"');
+  }
 
-    // prefix rgb with # in case it's not
-    if (!rgb.startsWith('#')) {
-        rgb = '#' + rgb;
-    }
+  // prefix rgb with # in case it's not
+  if (!rgb.startsWith('#')) {
+    rgb = '#' + rgb;
+  }
 
-    // throw an error if we didn't understand this color
-    if (rgb.length != 7) {
-        throw new Error('TJBot did not understand the specified color "' + color + '"');
-    }
+  // throw an error if we didn't understand this color
+  if (rgb.length != 7) {
+    throw new Error('TJBot did not understand the specified color "' + color + '"');
+  }
 
-    return rgb;
+  return rgb;
 }
 
 /** ------------------------------------------------------------------------ */
@@ -1077,112 +1096,111 @@ TJBot.prototype._normalizeColor = function(color) {
  * @param {String} message The message to speak.
  */
 TJBot.prototype.speak = function(message) {
-    this._assertCapability('speak');
+  this._assertCapability('speak');
 
-    // make sure we're trying to say something
-    if (message == undefined || message == "") {
-        winston.error("TJBot tried to speak an empty message.");
-        return; // exit if theres nothing to say!
+  // make sure we're trying to say something
+  if (message == undefined || message == "") {
+    winston.error("TJBot tried to speak an empty message.");
+    return; // exit if theres nothing to say!
+  }
+
+  // default voice
+  var voice = "en-US_MichaelVoice";
+
+  // check to see if the user has specified a voice
+  if (this.configuration.speak.voice != undefined) {
+    voice = this.configuration.speak.voice;
+  } else {
+    // choose a voice based on robot.gender and speak.language
+    // do this each time just in case the user changes robot.gender or
+    // speak.language during execution
+    for (var i in this._ttsVoices) {
+      if (this._ttsVoices[i]["language"] == this.configuration.speak.language &&
+        this._ttsVoices[i]["gender"] == this.configuration.robot.gender) {
+        voice = this._ttsVoices[i]["name"];
+        break;
+      }
     }
+  }
 
-    // default voice
-    var voice = "en-US_MichaelVoice";
+  winston.verbose("TJBot speaking with voice " + voice);
 
-    // check to see if the user has specified a voice
-    if (this.configuration.speak.voice != undefined) {
-        voice = this.configuration.speak.voice;
-    } else {
-        // choose a voice based on robot.gender and speak.language
-        // do this each time just in case the user changes robot.gender or
-        // speak.language during execution
-        for (var i in this._ttsVoices) {
-            if (this._ttsVoices[i]["language"] == this.configuration.speak.language &&
-                this._ttsVoices[i]["gender"] == this.configuration.robot.gender) {
-                voice = this._ttsVoices[i]["name"];
-                break;
-            }
-        }
-    }
+  var utterance = {
+    text: message,
+    voice: voice,
+    accept: 'audio/wav'
+  };
 
-    winston.verbose("TJBot speaking with voice " + voice);
+  // capture 'this' context
+  var self = this;
 
-    var utterance = {
-        text: message,
-        voice: voice,
-        accept: 'audio/wav'
-    };
+  return new Promise(function(resolve, reject) {
+    temp.open('tjbot', function(err, info) {
+      if (err) {
+        reject("error: could not open temporary file for writing at path: " + info.path);
+      }
 
-    // capture 'this' context
-    var self = this;
+      self._tts.synthesize(utterance)
+        .pipe(fs.createWriteStream(info.path))
+        .on('close', function() {
+          winston.debug("wrote audio stream to temp file", info.path);
+          winston.verbose("TJBot speaking: " + message);
 
-    return new Promise(function(resolve, reject) {
-        temp.open('tjbot', function(err, info) {
-            if (err) {
-                reject("error: could not open temporary file for writing at path: " + info.path);
-            }
-
-            self._tts.synthesize(utterance)
-                .pipe(fs.createWriteStream(info.path))
-                .on('close', function() {
-                    winston.debug("wrote audio stream to temp file", info.path);
-                    winston.verbose("TJBot speaking: " + message);
-
-                    resolve(self.play(info.path));
-                });
+          resolve(self.play(info.path));
         });
     });
+  });
 }
 
 /**
  * Play a given sound file.
  *
  * @param {String} soundFile The sound file to be played .
+ *
  */
 TJBot.prototype.play = function(soundFile) {
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    // pause listening while we play a sound -- using the internal
-    // method to avoid a capability check (and potential fail if the TJBot
-    // isn't configured to listen)
-    self._pauseListening();
+  // pause listening while we play a sound -- using the internal
+  // method to avoid a capability check (and potential fail if the TJBot
+  // isn't configured to listen)
+  self._pauseListening();
 
-    return new Promise(function(resolve, reject) {
-        // if we don't have a speaker, throw an error
-        if (self._soundplayer == undefined) {
-            reject(new Error("unable to play audio, TJBot hardware doesn't include a \"speaker\""));
-            return;
-        }
+  if (typeof soundFile == 'string') {
+    self.playerOptions.filename = soundFile
+  } else {
+    self.configuration = Object.assign({}, self.playerOptions, soundFile);
+  }
 
-        // initialize soundplayer lib
-        var speakerOptions = {
-            filename: soundFile,
-            gain: 100,
-            debug: true,
-            player: "aplay", // "afplay" "aplay" "mpg123" "mpg321"
-            device: self.configuration.speak.speakerDeviceId
-        }
-        var player = new self._soundplayer(speakerOptions);
+  return new Promise(function(resolve, reject) {
+    // if we don't have a speaker, throw an error
+    if (self._soundplayer == undefined) {
+      reject(new Error("unable to play audio, TJBot hardware doesn't include a \"speaker\""));
+      return;
+    }
 
-        winston.debug("Playing audio with parameters: ", speakerOptions);
+    var player = new self._soundplayer(self.playerOptions);
 
-        player.on('complete', function() {
-            winston.debug("audio playback finished");
+    winston.debug("Playing audio with parameters: ", self.playerOptions);
 
-            // resume listening
-            self._resumeListening();
+    player.on('complete', function() {
+      winston.debug("audio playback finished");
 
-            // done
-            resolve();
-        });
+      // resume listening
+      self._resumeListening();
 
-        player.on('error', function(err) {
-            winston.error('Error occurred while playing audio :', err);
-        });
-
-        // play the audio
-        player.play(soundFile);
+      // done
+      resolve();
     });
+
+    player.on('error', function(err) {
+      winston.error('Error occurred while playing audio :', err);
+    });
+
+    // play the audio
+    player.play(self.playerOptions);
+  });
 }
 
 /** ------------------------------------------------------------------------ */
@@ -1197,24 +1215,24 @@ TJBot.prototype.play = function(soundFile) {
  * @param {String} targetLanguage The target language (e.g. "es" for Spanish)
  */
 TJBot.prototype.translate = function(text, sourceLanguage, targetLanguage) {
-    this._assertCapability('translate');
+  this._assertCapability('translate');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        self._languageTranslator.translate({
-            text: text,
-            source: sourceLanguage,
-            target: targetLanguage
-        }, function(err, translation) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(translation);
-            }
-        });
+  return new Promise(function(resolve, reject) {
+    self._languageTranslator.translate({
+      text: text,
+      source: sourceLanguage,
+      target: targetLanguage
+    }, function(err, translation) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(translation);
+      }
     });
+  });
 }
 
 /**
@@ -1225,22 +1243,22 @@ TJBot.prototype.translate = function(text, sourceLanguage, targetLanguage) {
  * Returns a list of identified languages in the text.
  */
 TJBot.prototype.identifyLanguage = function(text) {
-    this._assertCapability('translate');
+  this._assertCapability('translate');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    return new Promise(function(resolve, reject) {
-        self._languageTranslator.identify({
-            text: text
-        }, function(err, identifiedLanguages) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(identifiedLanguages);
-            }
-        });
+  return new Promise(function(resolve, reject) {
+    self._languageTranslator.identify({
+      text: text
+    }, function(err, identifiedLanguages) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(identifiedLanguages);
+      }
     });
+  });
 }
 
 /**
@@ -1253,58 +1271,58 @@ TJBot.prototype.identifyLanguage = function(text) {
  * to the targetLanguage.
  */
 TJBot.prototype.isTranslatable = function(sourceLanguage, targetLanguage) {
-    this._assertCapability('translate');
+  this._assertCapability('translate');
 
-    // capture 'this' context
-    var self = this;
+  // capture 'this' context
+  var self = this;
 
-    // load the list of language models available for translation
-    if (this._translations == undefined) {
-        return this._loadLanguageTranslations().then(function(translations) {
-            self._translations = translations;
-            return self._isTranslatable(sourceLanguage, targetLanguage);
-        });
-    } else {
-        return new Promise(function(resolve, reject) {
-            resolve(self._isTranslatable(sourceLanguage, targetLanguage));
-        });
-    }
+  // load the list of language models available for translation
+  if (this._translations == undefined) {
+    return this._loadLanguageTranslations().then(function(translations) {
+      self._translations = translations;
+      return self._isTranslatable(sourceLanguage, targetLanguage);
+    });
+  } else {
+    return new Promise(function(resolve, reject) {
+      resolve(self._isTranslatable(sourceLanguage, targetLanguage));
+    });
+  }
 }
 
 /**
  * Loads the list of language models that can be used for translation.
  */
 TJBot.prototype._loadLanguageTranslations = function() {
-    // capture 'this' context
-    var self = this;
-    return new Promise(function(resolve, reject) {
-        if (self._translations == undefined) {
-            self._languageTranslator.getModels({}, function(err, models) {
-                var translations = {};
-                if (err) {
-                    winston.error("unable to retrieve list of language models for translation", err);
-                    reject(err);
-                } else {
-                    if (models.hasOwnProperty('models')) {
-                        models.models.forEach((model) => {
-                            if (translations[model.source] == undefined) {
-                                translations[model.source] = [];
-                            }
-                            if (!translations[model.source].includes(model.target)) {
-                                translations[model.source].push(model.target);
-                            }
-                        });
-                    } else {
-                        winston.error("unexpected result received for list of language models for translation");
-                        reject(err);
-                    }
-                }
-                resolve(translations);
-            });
+  // capture 'this' context
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    if (self._translations == undefined) {
+      self._languageTranslator.getModels({}, function(err, models) {
+        var translations = {};
+        if (err) {
+          winston.error("unable to retrieve list of language models for translation", err);
+          reject(err);
         } else {
-            resolve(translations);
+          if (models.hasOwnProperty('models')) {
+            models.models.forEach((model) => {
+              if (translations[model.source] == undefined) {
+                translations[model.source] = [];
+              }
+              if (!translations[model.source].includes(model.target)) {
+                translations[model.source].push(model.target);
+              }
+            });
+          } else {
+            winston.error("unexpected result received for list of language models for translation");
+            reject(err);
+          }
         }
-    });
+        resolve(translations);
+      });
+    } else {
+      resolve(translations);
+    }
+  });
 }
 
 /**
@@ -1317,11 +1335,11 @@ TJBot.prototype._loadLanguageTranslations = function() {
  * Returns true if the sourceLanguage can be translated to the targetLanguage.
  */
 TJBot.prototype._isTranslatable = function(sourceLanguage, targetLanguage) {
-    if (this._translations[sourceLanguage] != undefined) {
-        return this._translations[sourceLanguage].includes(targetLanguage);
-    }
+  if (this._translations[sourceLanguage] != undefined) {
+    return this._translations[sourceLanguage].includes(targetLanguage);
+  }
 
-    return false;
+  return false;
 }
 
 /** ------------------------------------------------------------------------ */
@@ -1336,47 +1354,47 @@ TJBot.prototype._SERVO_ARM_DOWN = 2300;
  * Move TJ's arm all the way back.
  */
 TJBot.prototype.armBack = function() {
-    // make sure we have an arm
-    this._assertCapability('wave');
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_BACK);
+  // make sure we have an arm
+  this._assertCapability('wave');
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_BACK);
 }
 
 /**
  * Raise TJ's arm.
  */
 TJBot.prototype.raiseArm = function() {
-    // make sure we have an arm
-    this._assertCapability('wave');
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
+  // make sure we have an arm
+  this._assertCapability('wave');
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
 }
 
 /**
  * Lower TJ's arm.
  */
 TJBot.prototype.lowerArm = function() {
-    // make sure we have an arm
-    this._assertCapability('wave');
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_DOWN);
+  // make sure we have an arm
+  this._assertCapability('wave');
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_DOWN);
 }
 
 /**
  * Wave TJ's arm.
  */
 TJBot.prototype.wave = function() {
-    this._assertCapability('wave');
+  this._assertCapability('wave');
 
-    var delay = 200;
+  var delay = 200;
 
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
-    this.sleep(delay);
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
+  this.sleep(delay);
 
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_DOWN);
-    this.sleep(delay);
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_DOWN);
+  this.sleep(delay);
 
-    this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
-    this.sleep(delay);
+  this._motor.servoWrite(TJBot.prototype._SERVO_ARM_UP);
+  this.sleep(delay);
 
-    return true;
+  return true;
 }
 
 /** ------------------------------------------------------------------------ */

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -674,8 +674,6 @@ TJBot.prototype.listen = function(callback) {
   if (this.configuration.listen.customizationId) recognizerParams.customization_id = this.configuration.listen.customizationId;
   this._micRecognizeStream = this._stt.createRecognizeStream(recognizerParams);
 
-  console.log(recognizerParams)
-
   // create the mic -> STT recognizer -> text stream
   this._micTextStream = this._micInputStream.pipe(this._micRecognizeStream);
   this._micTextStream.setEncoding('utf8');

--- a/test/config.default.js
+++ b/test/config.default.js
@@ -1,9 +1,91 @@
+exports.webServerNumber = 8078;
+
+// User-specific CONFIGURATION
+exports.conversationWorkspaceId = '';
+
+// Tjbot library config - modify as needed
+exports.tjConfig = {
+  log: {
+    level: 'verbose'
+  },
+  listen: {
+    microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
+    inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
+    language: 'en-US', // see TJBot.prototype.languages.listen
+    customizationId: '' // to use speech to text language model customizations
+  },
+  speak: {
+    language: 'en-US', // see TJBot.prototype.languages.speak
+    voice: undefined, // use a specific voice; if undefined, a voice is chosen based on robot.gender and speak.language
+    speakerDeviceId: "plughw:0,0", // plugged-in USB card 1, device 0; see aplay -l for a list of playback devices
+    soundPlayer: "ffplay",
+    queueSpeech: false //// queue a request to play/speak if there is something already playing.
+  },
+  see: {
+    confidenceThreshold: {
+      object: 0.5, // only list image tags with confidence > 0.5
+      text: 0.1 // only list text tags with confidence > 0.5
+    },
+    camera: {
+      height: 720,
+      width: 960,
+      verticalFlip: false, // flips the image vertically, may need to set to 'true' if the camera is installed upside-down
+      horizontalFlip: false // flips the image horizontally, should not need to be overridden
+    }
+  }
+};
+// Setup Weather location details
+
+exports.weather = {
+  city: "denver",
+  state: "CO",
+  country: "US"
+}
+
 // Create the credentials object for export
 exports.credentials = {};
+
+// Watson Conversation
+// https://www.ibm.com/watson/developercloud/conversation.html
+exports.credentials.conversation = {
+  password: '',
+  username: ''
+};
 
 // Watson Speech to Text
 // https://www.ibm.com/watson/developercloud/speech-to-text.html
 exports.credentials.speech_to_text = {
-    password: '',
-    username: ''
+  password: '',
+  username: ''
+};
+
+// Watson Text to Speech
+// https://www.ibm.com/watson/developercloud/text-to-speech.html
+exports.credentials.text_to_speech = {
+  password: '',
+  username: ''
+};
+
+// Watson Tone Analyzer
+// https://www.ibm.com/watson/developercloud/text-to-speech.html
+exports.credentials.tone_analyzer = {
+  password: '',
+  username: ''
+};
+
+// Watson Vision Recognition
+// https://www.ibm.com/watson/developercloud/text-to-speech.html
+exports.credentials.visual_recognition = {
+  api_key: '',
+  version: '2016-05-19'
+}
+
+// IBM Weather Company
+// https://www.ibm.com/watson/developercloud/text-to-speech.html
+exports.credentials.weather = {
+  url: "",
+  username: ' ',
+  password: ' ',
+  host: " ",
+  port: 443,
 };


### PR DESCRIPTION
Support a couple new options
- CustomizationId: Allowing users specify a custom language model to improve accuracy of speech-to-text transcription. For more on language models see [here](https://console.bluemix.net/docs/services/speech-to-text/language-create.html ). To specify this, they add the following line to `tjconfig` .
```javascript
listen: {
    microphoneDeviceId: "plughw:1,0", // plugged-in USB card 1, device 0; see arecord -l for a list of recording devices
    inactivityTimeout: -1, // -1 to never timeout or break the connection. Set this to a value in seconds e.g 120 to end connection after 120 seconds of silence
    language: 'en-US', // see TJBot.prototype.languages.listen
    customizationId: '' // to use speech to text language model customizations
  }

- Specify soundplayer. Allows users specify which soundplayer they would like to use in the `tj.play()` method. They can set this in `tjconfig` 

```javascript
speak: {
    language: 'en-US', // see TJBot.prototype.languages.speak
    voice: undefined, // use a specific voice; if undefined, a voice is chosen based on robot.gender and speak.language
    speakerDeviceId: "plughw:0,0", // plugged-in USB card 1, device 0; see aplay -l for a list of playback devices
    soundPlayer: "ffplay",
    queueSpeech: false //// queue a request to play/speak if there is something already playing.
  }
```
or send a parameter file as input to` tj.play()`
```javascript
var playParams = {
  filename: "preview.mp3",
  gain: 40,
  debug: true,
  player: "ffplay",
}

tj.play(playParams)
```

This way, devs can easily prototype voice aspects of their tjbot apps (stt, tts, conversation etc) on a mac before deploying exact same code to tjbot.