### PR TITLE
Support for custom language in visual recognition

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -169,7 +169,8 @@ TJBot.prototype.defaultConfiguration = {
             width: 960,
             verticalFlip: false, // flips the image vertically, may need to set to 'true' if the camera is installed upside-down
             horizontalFlip: false // flips the image horizontally, should not need to be overridden
-        }
+        },
+        language: 'en'
     }
 };
 
@@ -180,6 +181,7 @@ TJBot.prototype.configurationParameters = Object.keys(TJBot.prototype.defaultCon
 TJBot.prototype.languages = {};
 TJBot.prototype.languages.listen = ['ar-AR', 'en-UK', 'en-US', 'es-ES', 'fr-FR', 'ja-JP', 'pt-BR', 'zh-CN'];
 TJBot.prototype.languages.speak = ['en-GB', 'en-US', 'es-US', 'ja-JP', 'pt-BR'];
+TJBot.prototype.languages.see = ['en','ar','de','es','it','ja','ko'];
 TJBot.prototype.genders = ['male', 'female'];
 
 /** ------------------------------------------------------------------------ */
@@ -781,7 +783,8 @@ TJBot.prototype.recognizeObjectsInPhoto = function(filePath) {
         winston.debug("sending image to Watson Visual Recognition");
         var params = {
             images_file: fs.createReadStream(filePath),
-            threshold: self.configuration.see.confidenceThreshold.object
+            threshold: self.configuration.see.confidenceThreshold.object,
+            'Accept-Language': self.configuration.see.language
         };
 
         self._visualRecognition.classify(params, function(err, response) {
@@ -828,7 +831,8 @@ TJBot.prototype.recognizeTextInPhoto = function(filePath) {
         winston.debug("sending image to Watson Visual Recognition to recognize text.");
         var params = {
             images_file: fs.createReadStream(filePath),
-            threshold: self.configuration.see.confidenceThreshold.text
+            threshold: self.configuration.see.confidenceThreshold.text,
+            'Accept-Language': self.configuration.see.language
         };
 
         self._visualRecognition.recognizeText(params, function(err, response) {


### PR DESCRIPTION
Added configuration to support custom language definitions from the visual recognition service. The default configuration stands as English. However now language can be customized to the 2-letter primary language code as assigned in ISO standard 639. Supported languages are en (English), ar (Arabic), de (German), es (Spanish), it (Italian), ja (Japanese), and ko (Korean). Now a specific language can be set under the 'see' segment of configuration. For example to set it to spanish:

see: {
  confidenceThreshold: { 
    object: 0.5,
    text: 0.1 },
    camera: {
        height: 720,
        width: 960,
        verticalFlip: false,
        horizontalFlip: false
    },
    language:'es' // Sets the language to spanish 
}

Signed-off-by: Baltazar Rodriguez <rtellez@mx1.ibm.com>