### PR TITLE
Visual Recognition IAM API key support is now the only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ var credentials = {
 		password: 'yyy'
 	},
 	visual_recognition: {
-		api_key: 'xxx'
+		iam_apikey: 'xxx'
 	}
 };
 ```

--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -426,20 +426,15 @@ TJBot.prototype._createServiceAPI = function(service, credentials) {
             break;
 
         case 'visual_recognition':
-            assert(credentials.hasOwnProperty('api_key'), "credentials for the " + service + " service missing 'api_key'");
+            assert(credentials.hasOwnProperty('iam_apikey'), "credentials for the " + service + " service missing 'iam_apikey'");
 
             var VisualRecognitionV3 = require('watson-developer-cloud/visual-recognition/v3');
             
             // see this note about authentication:
             // https://www.ibm.com/watson/developercloud/visual-recognition/api/v3/node.html?node#authentication
-            if (credentials['api_key'] != undefined) {
+            if (credentials['iam_apikey'] != undefined) {
                 this._visualRecognition = new VisualRecognitionV3({
-                    api_key: credentials['api_key'],
-                    version: '2018-03-19'
-                });
-            } else if (credentials['iam_apikey'] != undefined) {
-                this._visualRecognition = new VisualRecognitionV3({
-                    api_key: credentials['iam_apikey'],
+                    iam_apikey: credentials['iam_apikey'],
                     version: '2018-03-19'
                 });
             } else {


### PR DESCRIPTION
Per changes with the Visual Recognition API, IAM API Keys are now the only supported authentication option (10/1 change log https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#release-notes).

Removed support for the old API key, and updated the documentation. This is a breaking change, however, the old method no longer works. 