### PR TITLE
fix error message on create visual_recognition

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -540,7 +540,7 @@ TJBot.prototype._createServiceAPI = function(service, credentials) {
             });
         } else {
             throw new Error(
-                'Missing authentication credentials for tone_analyzer service: username/password or ' +
+                'Missing authentication credentials for visual_recognition service: username/password or ' +
                 'apikey are required.');
         }
         break;


### PR DESCRIPTION
fixed error, when credentials for visual recognition were not provided, a error message relating to tone_analyzer was raised.