### PR TITLE
Language selection FIX of the image recognition methods

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -784,7 +784,7 @@ TJBot.prototype.recognizeObjectsInPhoto = function(filePath) {
         var params = {
             images_file: fs.createReadStream(filePath),
             threshold: self.configuration.see.confidenceThreshold.object,
-            'Accept-Language': self.configuration.see.language
+            accept_language: self.configuration.see.language
         };
 
         self._visualRecognition.classify(params, function(err, response) {
@@ -832,7 +832,7 @@ TJBot.prototype.recognizeTextInPhoto = function(filePath) {
         var params = {
             images_file: fs.createReadStream(filePath),
             threshold: self.configuration.see.confidenceThreshold.text,
-            'Accept-Language': self.configuration.see.language
+            accept_language: self.configuration.see.language
         };
 
         self._visualRecognition.recognizeText(params, function(err, response) {


### PR DESCRIPTION
The visual recognition methods require the accept_language parameter not 'Accept-Language', for example, in the v3-generated.js file segment bellow, from watson-developer-cloud library:

    127             defaultOptions: extend(true, {}, this._options, {
    128                 headers: extend(true, sdkHeaders, {
    129                     'Accept': 'application/json',
    130                     'Content-Type': 'multipart/form-data',
    131                     'Accept-Language': _params.accept_language
    132                 }, _params.headers),
    133             }),
    134         };

With this FIX, the parameter language in the config.js file will be taken correctly.