### PR TITLE
change sample rate and number of channels for the microphone

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -252,8 +252,8 @@ TJBot.prototype._setupMicrophone = function() {
     winston.verbose('TJBot initializing microphone');
 
     var micParams = {
-        'rate': '44100',
-        'channels': '2',
+        'rate': '16000',
+        'channels': '1',
         'debug': false,
         'exitOnSilence': 6
     };
@@ -759,7 +759,7 @@ TJBot.prototype.listen = function(callback) {
     // see this page for additional documentation on the STT configuration parameters:
     // https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#recognize_audio_websockets
     var params = {
-        content_type: 'audio/l16; rate=44100; channels=2',
+        content_type: 'audio/l16; rate=16000; channels=1',
         interim_results: true, // need 'true' for watson-developer-cloud 3.x, otherwise results don't come back
         model: this.configuration.listen.language + '_BroadbandModel'
     };


### PR DESCRIPTION
I propose to change the sample rate to 16000 and the number of channels to 1, as it doesn't make much sense to use 44000 and 2 channels. Most microphones attached to a TJBot are cheap (low quality) we cannot expect to cover frequencies up to 22Khz accurately and will record in mono. 
Also, STT service recommends to:

https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-audio-formats

The service supports both broadband and narrowband audio for most languages and formats. It automatically adjusts the sampling rate of your audio to match the model that you specify before it recognizes speech.

- For broadband models, the service converts audio recorded at higher sampling rates to 16 kHz.
- For narrowband models, it converts the audio to 8 kHz.

In theory, you can send 44 kHz audio with a broadband or narrowband model, but that needlessly increases the size of the audio. To maximize the amount of audio that you can send, match the sampling rate of your audio to the model that you use. The service does not accept audio that is sampled at a rate that is less than the intrinsic sampling rate of the model.

Therefore, the change is justified by the documentation.
Finally, I did several tests with TJBot on a raspberry pi with and the results are much better with these settings.

Thanks,
Jaime- 


