### PR TITLE
Fixing Visual Recognition API Call issue

### DIFF
--- a/lib/tjbot.js
+++ b/lib/tjbot.js
@@ -920,7 +920,7 @@ TJBot.prototype.recognizeObjectsInPhoto = function(filePath, classifier_ids) {
             'Accept-Language': self.configuration.see.language
         };
 
-        if (classifier_ids != undefined) {
+        if (classifier_ids != undefined && classifier_ids.length) {
             params['classifier_ids'] = classifier_ids;
             params['owners'] = ['me'];
         }


### PR DESCRIPTION
Adding additional check to see if the classifier_ids array actually contains any values.
Else an empty array is sent by default to the visual recognition api, which results in the following error message: 
"Invalid Request: provided vmodel-id header must be non-empty"