### PR TITLE
update package.json with "rpi-ws281x-native": "^0.10.1" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mic": "^2.1.2",
     "node-raspistill": "^1.0.1",
     "pigpio": "^3.2.3",
-    "rpi-ws281x-native": "^0.10.0",
+    "rpi-ws281x-native": "^0.10.1",
     "semaphore": "^1.1.0",
     "sleep": "^6.3.0",
     "sound-player": "^1.0.13",


### PR DESCRIPTION
The update of this dependency to 0.10.1 contains a fix to include support for a new revision code on the Raspberry Pi 4s that use bcm2711.